### PR TITLE
Bump minimum SDK version to 26

### DIFF
--- a/examples/minibrowser/build.gradle
+++ b/examples/minibrowser/build.gradle
@@ -9,7 +9,7 @@ android {
 
     defaultConfig {
         applicationId "com.wpe.examples.minibrowser"
-        minSdkVersion 23
+        minSdkVersion 26
         targetSdkVersion 30
         versionCode 1
         versionName "1.0"

--- a/wpe/build.gradle
+++ b/wpe/build.gradle
@@ -7,7 +7,7 @@ android {
     buildToolsVersion "30.0.3"
 
     defaultConfig {
-        minSdkVersion 23
+        minSdkVersion 26
         targetSdkVersion 30
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
This is a precursory change for the AHardwareBuffer-based approach to
buffer management.