### PR TITLE
Clamp down move, copy constructors and assignment operators for the m…

### DIFF
--- a/wpe/src/main/glue/browser/browser.cpp
+++ b/wpe/src/main/glue/browser/browser.cpp
@@ -70,7 +70,7 @@ void Browser::runMainLoop() {
 void Browser::newPage(int pageId, int width, int height, std::shared_ptr<PageEventObserver> observer)
 {
     ALOGV("Browser::newPage");
-    auto page = std::make_unique<Page>(Page(width, height, observer));
+    auto page = std::make_unique<Page>(width, height, observer);
     g_main_context_invoke_full(*m_uiProcessThreadContext, G_PRIORITY_DEFAULT, [](gpointer data) -> gboolean {
         auto *page = reinterpret_cast<Page*>(data);
         if (page != nullptr) {

--- a/wpe/src/main/glue/browser/browser.h
+++ b/wpe/src/main/glue/browser/browser.h
@@ -19,6 +19,11 @@ public:
         return *m_instance;
     }
 
+    Browser(Browser&&) = delete;
+    Browser& operator=(Browser&&) = delete;
+    Browser(const Browser&) = delete;
+    Browser& operator=(const Browser&) = delete;
+
     ~Browser() {
         deinit();
     }

--- a/wpe/src/main/glue/browser/page.h
+++ b/wpe/src/main/glue/browser/page.h
@@ -13,6 +13,11 @@
 class Page {
 public:
     Page(int width, int height, std::shared_ptr<PageEventObserver>);
+    Page(Page&&) = delete;
+    Page& operator=(Page&&) = delete;
+    Page(const Page&) = delete;
+    Page& operator=(const Page&) = delete;
+
     void init();
     void close();
 

--- a/wpe/src/main/glue/browser/pageeventobserver.h
+++ b/wpe/src/main/glue/browser/pageeventobserver.h
@@ -10,6 +10,10 @@ class PageEventObserver {
 
 public:
     PageEventObserver(JavaVM *vm, jclass klass, jobject obj) : vm(vm), pageClass(klass), pageObj(obj) {}
+    PageEventObserver(PageEventObserver&&) = delete;
+    PageEventObserver& operator=(PageEventObserver&&) = delete;
+    PageEventObserver(const PageEventObserver&) = delete;
+    PageEventObserver& operator=(const PageEventObserver&) = delete;
     ~PageEventObserver();
 
     void onLoadChanged(WebKitLoadEvent);


### PR DESCRIPTION
…ain C++ classes

Explicitly delete move and copy constructors and assignment operators, preventing
the classes to be effectively moved or copied around. We don't need this behavior
for the moment and it will probably won't be needed in the future either, but it
will prevent dangling references.