### PR TITLE
Handle touch events at G_PRIORITY_DEFAULT priority

### DIFF
--- a/wpe/src/main/glue/browser/browser.cpp
+++ b/wpe/src/main/glue/browser/browser.cpp
@@ -146,7 +146,7 @@ void Browser::onTouch(int pageId, jlong time, jint type, jfloat x, jfloat y)
     touchEventRaw->y = (int32_t) y;
 
     auto *data = new OnTouchData { m_pages[pageId].get(), touchEventRaw };
-    g_main_context_invoke_full(*m_uiProcessThreadContext, G_PRIORITY_HIGH + 30, [](gpointer data) -> gboolean {
+    g_main_context_invoke_full(*m_uiProcessThreadContext, G_PRIORITY_DEFAULT, [](gpointer data) -> gboolean {
         auto *touchData = reinterpret_cast<OnTouchData*>(data);
         if (touchData->page != nullptr) {
             touchData->page->onTouch(touchData->touchEvent);


### PR DESCRIPTION
Don't use a higher priority than that since it can drain out other
frequently-dispatched sources that use the default priority.