### PR TITLE
Add a Looper-based helper thread

### DIFF
--- a/wpe/CMakeLists.txt
+++ b/wpe/CMakeLists.txt
@@ -54,10 +54,12 @@ add_library(WPEBrowserGlue SHARED
         src/main/glue/browser/pageeventobserver.cpp
         src/main/glue/browser/entrypoints.cpp
         src/main/glue/browser/browser.cpp
+        src/main/glue/browser/looperthread.cpp
         src/main/glue/browser/page.cpp
         )
 
 target_link_libraries(WPEBrowserGlue
+        ${android-lib}
         ${log-lib}
         gio-2.0
         glib-2.0

--- a/wpe/src/main/glue/browser/entrypoints.cpp
+++ b/wpe/src/main/glue/browser/entrypoints.cpp
@@ -6,10 +6,12 @@
 
 #include "browser.h"
 #include "logging.h"
+#include "looperthread.h"
 #include "pageeventobserver.h"
 
 extern "C" {
     JNIEXPORT void JNICALL Java_com_wpe_wpe_BrowserGlue_init(JNIEnv*, jobject, jobject);
+    JNIEXPORT void JNICALL Java_com_wpe_wpe_BrowserGlue_initLooperHelper(JNIEnv*, jobject);
     JNIEXPORT void JNICALL Java_com_wpe_wpe_BrowserGlue_deinit(JNIEnv*, jobject);
 
     JNIEXPORT void JNICALL Java_com_wpe_wpe_BrowserGlue_newPage(JNIEnv*, jobject, jobject, jint, jint, jint);
@@ -39,6 +41,13 @@ Java_com_wpe_wpe_BrowserGlue_init(JNIEnv* env, jobject, jobject glueObj)
     s_BrowserGlue_env = env;
     s_BrowserGlue_object = glueObj;
     Browser::getInstance().init();
+}
+
+JNIEXPORT void JNICALL
+Java_com_wpe_wpe_BrowserGlue_initLooperHelper(JNIEnv* env, jobject)
+{
+    ALOGV("BrowserGlue.initLooperHelper()");
+    LooperThread::initialize();
 }
 
 JNIEXPORT void JNICALL

--- a/wpe/src/main/glue/browser/looperthread.cpp
+++ b/wpe/src/main/glue/browser/looperthread.cpp
@@ -1,0 +1,24 @@
+#include "looperthread.h"
+
+#include "logging.h"
+#include <android/looper.h>
+
+static LooperThread* s_looperThread;
+
+LooperThread::~LooperThread()
+{
+    ALooper_release(m_looper);
+}
+
+void LooperThread::initialize()
+{
+    ALOGV("LooperThread::initialize() ALooper %p", ALooper_forThread());
+    s_looperThread = new LooperThread;
+    s_looperThread->m_looper = ALooper_forThread();
+    ALooper_acquire(s_looperThread->m_looper);
+}
+
+LooperThread& LooperThread::instance()
+{
+    return *s_looperThread;
+}

--- a/wpe/src/main/glue/browser/looperthread.h
+++ b/wpe/src/main/glue/browser/looperthread.h
@@ -1,0 +1,16 @@
+#pragma once
+
+struct ALooper;
+
+class LooperThread {
+public:
+    static void initialize();
+    static LooperThread& instance();
+
+    ~LooperThread();
+
+    ALooper* looper() const { return m_looper; }
+
+private:
+    ALooper* m_looper { nullptr };
+};

--- a/wpe/src/main/java/com/wpe/wpe/BrowserGlue.java
+++ b/wpe/src/main/java/com/wpe/wpe/BrowserGlue.java
@@ -18,6 +18,7 @@ public class BrowserGlue {
     }
 
     public static native void init(BrowserGlue self);
+    public static native void initLooperHelper();
     public static native void deinit();
 
     public static native void newPage(Page page, int pageId, int width, int height);


### PR DESCRIPTION
Along with the rest of the Browser glue, also initialize a dedicated thread
that will be spun by an ALooper object and the underlying Java-based Looper.
This will allow leveraging native APIs like AChoreographer which aren't able
to operate on any thread that's not run by a Looper.