### PR TITLE
browser: add a generic `invoke` method for dispatching just about any…

### DIFF
--- a/wpe/src/main/glue/browser/browser.h
+++ b/wpe/src/main/glue/browser/browser.h
@@ -26,6 +26,8 @@ public:
     void init();
     void deinit();
 
+    void invoke(void (*callback)(void*), void* callbackData, void (*destroy)(void*));
+
     void newPage(int pageId, int width, int height, std::shared_ptr<PageEventObserver> observer);
     void closePage(int pageId);
 


### PR DESCRIPTION
…thing

Add a more flexible Browser::invoke() that dispatches the passed-in callback
along with the associated data. This isn't tied to any specific Page method
that's supposed to be invoked, everything is left to the callback.

Hypothetically other dispatch methods that do relay a method call to the Page
object could switch to this approach, but this is left open for now.