### PR TITLE
Fix patch.py script error

### DIFF
--- a/scripts/patch.py
+++ b/scripts/patch.py
@@ -90,7 +90,12 @@ class Patch:
     def run(self):
         self.__cerbero_shell_build()
         sysroot = os.path.join(self.__build_dir, 'build', 'dist', 'android_' + self.__arch)
-        Bootstrap(self.__arch, False).install_deps(sysroot, self.__get_install_list())
+        args = type("", (), {
+          "arch": self.__arch,
+          "build": True,
+          "debug": False
+        })();
+        Bootstrap(args).install_deps(sysroot, self.__get_install_list())
 
 if __name__ == "__main__":
     if len(sys.argv) != 3:


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/mortimer/Projects/wpe-android/./scripts/patch.py", line 100, in <module>
    Patch(sys.argv[1], sys.argv[2]).run()
  File "/home/mortimer/Projects/wpe-android/./scripts/patch.py", line 93, in run
    Bootstrap(self.__arch, False).install_deps(sysroot, self.__get_install_list())
TypeError: __init__() takes 2 positional arguments but 3 were given
```