### PR TITLE
RendererASurfaceTransaction redraw fixes

### DIFF
--- a/wpe/src/main/glue/browser/renderer_asurfacetransaction.cpp
+++ b/wpe/src/main/glue/browser/renderer_asurfacetransaction.cpp
@@ -12,8 +12,13 @@
 struct RendererASurfaceTransaction::TransactionContext {
     RendererASurfaceTransaction& renderer;
     std::shared_ptr<ExportedBuffer> buffer;
-    bool dispatchFrameCompleteCallback;
 };
+
+static void releaseBuffer(struct wpe_android_view_backend_exportable* exportable, const ExportedBuffer& buffer)
+{
+    wpe_android_view_backend_exportable_dispatch_release_buffer(exportable,
+            buffer.buffer, buffer.poolID, buffer.bufferID);
+}
 
 RendererASurfaceTransaction::RendererASurfaceTransaction(Page& page, unsigned width, unsigned height)
     : m_page(page)
@@ -29,37 +34,46 @@ RendererASurfaceTransaction::~RendererASurfaceTransaction()
     if (m_surface.window)
         ANativeWindow_release(m_surface.window);
 
-    m_lockedBuffer = nullptr;
+    // Release the stored exported buffer, if any, and if different from the locked buffer.
+    // If the same, the buffer will be released via the locked buffer.
+    if (m_state.exportedBuffer && m_state.exportedBuffer != m_state.lockedBuffer)
+        releaseBuffer(m_page.exportable(), *m_state.exportedBuffer);
+    // If locked buffer still exists, release it.
+    if (m_state.lockedBuffer)
+        releaseBuffer(m_page.exportable(), *m_state.lockedBuffer);
+    m_state = { };
 }
 
 void RendererASurfaceTransaction::surfaceCreated(ANativeWindow* window)
 {
+    // This is now the surface we work with. We also spawn the corresponding ASurfaceControl.
     m_surface.window = window;
     m_surface.control = ASurfaceControl_createFromWindow(m_surface.window, "RendererASurfaceTransaction");
 }
 
 void RendererASurfaceTransaction::surfaceChanged(int format, unsigned width, unsigned height)
 {
+    // Update the size.
+    // FIXME: currently neither the format nor the stored size are used anywhere.
     m_size.width = width;
     m_size.height = height;
 }
 
 void RendererASurfaceTransaction::surfaceRedrawNeeded()
 {
+    // Nothing is doable if there's no ASurfaceControl.
     if (!m_surface.control)
         return;
 
-    if (!m_lockedBuffer)
-        return;
-    if (m_lockedBuffer->size.width != m_size.width || m_lockedBuffer->size.height != m_size.height)
-        return;
-
-    auto exportedBuffer = std::exchange(m_lockedBuffer, nullptr);
-    scheduleFrame(new TransactionContext { *this, exportedBuffer, false });
+    // Redraw is needed -- if there's currently an exported buffer present, reuse it.
+    if (m_state.exportedBuffer)
+        scheduleFrame(new TransactionContext { *this, m_state.exportedBuffer });
 }
 
 void RendererASurfaceTransaction::surfaceDestroyed()
 {
+    // Regular cleanup of the ASurfaceControl as well as the ANativeWindow.
+
     ASurfaceControl_release(m_surface.control);
     m_surface.control = nullptr;
 
@@ -69,15 +83,29 @@ void RendererASurfaceTransaction::surfaceDestroyed()
 
 void RendererASurfaceTransaction::handleExportedBuffer(const std::shared_ptr<ExportedBuffer>& exportedBuffer)
 {
+    // If there's an exported buffer being held that's different from the locked one, it has to
+    // be released here since it won't be released otherwise.
+    if (m_state.exportedBuffer && m_state.exportedBuffer != m_state.lockedBuffer)
+        releaseBuffer(m_page.exportable(), *m_state.exportedBuffer);
+
+    m_state.exportedBuffer = exportedBuffer;
+
+    // Each buffer export requires a corresponding frame-complete callback. This is signalled here.
+    m_state.dispatchFrameCompleteCallback = true;
+
+    // Nothing is doable if there's no ASurfaceControl.
     if (!m_surface.control)
         return;
 
-    ALOGV("RendererASurfaceTransaction::handleExportedBuffer()");
-    scheduleFrame(new TransactionContext { *this, exportedBuffer, true });
+    // Finally, schedule the new frame, presenting the just-exported buffer.
+    scheduleFrame(new TransactionContext { *this, m_state.exportedBuffer });
 }
 
 void RendererASurfaceTransaction::scheduleFrame(TransactionContext* transactionContext)
 {
+    // Take the TransactionContext and its buffer and form a transaction for it.
+    // Upon transaction completion, the buffer will be presented on the surface.
+
     ASurfaceTransaction* transaction = ASurfaceTransaction_create();
     ASurfaceTransaction_setVisibility(transaction, m_surface.control, ASURFACE_TRANSACTION_VISIBILITY_SHOW);
     ASurfaceTransaction_setZOrder(transaction, m_surface.control, 0);
@@ -89,33 +117,33 @@ void RendererASurfaceTransaction::scheduleFrame(TransactionContext* transactionC
     ASurfaceTransaction_delete(transaction);
 }
 
-void RendererASurfaceTransaction::finishFrame(const std::shared_ptr<ExportedBuffer>& exportedBuffer, bool dispatchFrameCompleteCallback)
+void RendererASurfaceTransaction::finishFrame(const std::shared_ptr<ExportedBuffer>& exportedBuffer)
 {
-    ALOGV("RendererASurfaceTransaction::finishFrame()");
+    ALOGV("RendererASurfaceTransaction::finishFrame() exportedBuffer %p", exportedBuffer.get());
 
-    if (m_lockedBuffer) {
-        wpe_android_view_backend_exportable_dispatch_release_buffer(m_page.exportable(),
-                                                                    m_lockedBuffer->buffer,
-                                                                    m_lockedBuffer->poolID,
-                                                                    m_lockedBuffer->bufferID);
-        m_lockedBuffer = nullptr;
-    }
-    m_lockedBuffer = exportedBuffer;
+    // If the current locked buffer is different from the current exported one, it should be released here.
+    if (m_state.lockedBuffer && m_state.exportedBuffer != m_state.lockedBuffer)
+        releaseBuffer(m_page.exportable(), *m_state.lockedBuffer);
 
-    if (dispatchFrameCompleteCallback)
+    // The just-presented buffer is now also the locked one.
+    m_state.lockedBuffer = exportedBuffer;
+
+    // If the frame-complete callback dispatch was requested, it's invoked here.
+    if (m_state.dispatchFrameCompleteCallback)
         wpe_android_view_backend_exportable_dispatch_frame_complete(m_page.exportable());
+    m_state.dispatchFrameCompleteCallback = false;
 }
 
 void RendererASurfaceTransaction::onTransactionComplete(void* data, ASurfaceTransactionStats* stats)
 {
     ALOGV("RendererASurfaceTransaction::onTransactionComplete() context %p", data);
-    auto* context = static_cast<TransactionContext*>(data);
 
+    // Relay the transaction completion to the browser thread.
     Browser::getInstance().invoke(
             [](void* data) {
                 auto* context = static_cast<TransactionContext*>(data);
-                context->renderer.finishFrame(context->buffer, context->dispatchFrameCompleteCallback);
-            }, context,
+                context->renderer.finishFrame(context->buffer);
+            }, data,
             [](void* data) {
                 delete static_cast<TransactionContext*>(data);
             });

--- a/wpe/src/main/glue/browser/renderer_asurfacetransaction.cpp
+++ b/wpe/src/main/glue/browser/renderer_asurfacetransaction.cpp
@@ -55,6 +55,7 @@ void RendererASurfaceTransaction::surfaceChanged(int format, unsigned width, uns
 {
     // Update the size.
     // FIXME: currently neither the format nor the stored size are used anywhere.
+    // https://github.com/Igalia/wpe-android/issues/36
     m_size.width = width;
     m_size.height = height;
 }

--- a/wpe/src/main/glue/browser/renderer_asurfacetransaction.h
+++ b/wpe/src/main/glue/browser/renderer_asurfacetransaction.h
@@ -26,7 +26,7 @@ public:
 private:
     struct TransactionContext;
     void scheduleFrame(TransactionContext*);
-    void finishFrame(const std::shared_ptr<ExportedBuffer>&, bool dispatchFrameCompleteCallback);
+    void finishFrame(const std::shared_ptr<ExportedBuffer>&);
 
     static void onTransactionComplete(void* data, ASurfaceTransactionStats* stats);
 
@@ -41,7 +41,12 @@ private:
         unsigned height;
     } m_size;
 
-    std::shared_ptr<ExportedBuffer> m_lockedBuffer;
+    struct {
+        bool dispatchFrameCompleteCallback { false };
+
+        std::shared_ptr<ExportedBuffer> exportedBuffer;
+        std::shared_ptr<ExportedBuffer> lockedBuffer;
+    } m_state;
 };
 
 #endif

--- a/wpe/src/main/java/com/wpe/wpe/BrowserGlue.java
+++ b/wpe/src/main/java/com/wpe/wpe/BrowserGlue.java
@@ -33,6 +33,7 @@ public class BrowserGlue {
 
     public static native void surfaceCreated(int pageId, Surface surface);
     public static native void surfaceChanged(int pageId, int format, int width, int height);
+    public static native void surfaceRedrawNeeded(int pageId);
     public static native void surfaceDestroyed(int pageId);
 
     public static native void touchEvent(int pageId, long time, int type, float x, float y);

--- a/wpe/src/main/java/com/wpe/wpe/gfx/View.java
+++ b/wpe/src/main/java/com/wpe/wpe/gfx/View.java
@@ -65,6 +65,7 @@ public class View extends SurfaceView {
         public void surfaceRedrawNeeded(SurfaceHolder holder)
         {
             Log.d(m_view.LOGTAG, "HolderCallback::surfaceRedrawNeeded()");
+            BrowserGlue.surfaceRedrawNeeded(m_view.m_pageId);
         }
     }
 


### PR DESCRIPTION
* Adds the necessary entrypoint, invokes it from SurfaceHolder
* Fixes RendererASurfaceTransaction to properly handle and execute surface redraw requests coming from gfx.View
* Sprinkles comments inside the RendererASurfaceTransaction class to provide more insight into its behavior.