### PR TITLE
Add SurfaceClient API

### DIFF
--- a/wpe/src/main/java/com/wpe/wpe/Page.java
+++ b/wpe/src/main/java/com/wpe/wpe/Page.java
@@ -68,7 +68,7 @@ public class Page {
         m_width =  wpeView.getMeasuredWidth();
         m_height = wpeView.getMeasuredHeight();
 
-        m_view = new View(m_context, pageId);
+        m_view = new View(m_context, pageId, wpeView);
         m_wpeView.onViewCreated(m_view);
         onViewReady();
 

--- a/wpe/src/main/java/com/wpe/wpe/gfx/View.java
+++ b/wpe/src/main/java/com/wpe/wpe/gfx/View.java
@@ -8,9 +8,12 @@ import android.view.ScaleGestureDetector;
 import android.view.SurfaceHolder;
 import android.view.SurfaceView;
 
+import androidx.annotation.Nullable;
 import androidx.annotation.UiThread;
 
 import com.wpe.wpe.BrowserGlue;
+import com.wpe.wpeview.SurfaceClient;
+import com.wpe.wpeview.WPEView;
 
 @UiThread
 public class View extends SurfaceView {
@@ -76,16 +79,20 @@ public class View extends SurfaceView {
     private float mScaleFactor = 1.f;
     private boolean m_ignoreTouchEvent = false;
 
-    public View(Context context, int pageId) {
+    public View(Context context, int pageId, WPEView wpeView) {
         super(context);
 
         LOGTAG = "WPE gfx.View" + pageId;
 
         m_pageId = pageId;
 
-        SurfaceHolder holder = getHolder();
-        Log.d(LOGTAG, "View: holder " + holder);
-        holder.addCallback(new HolderCallback(this));
+        if (wpeView.getSurfaceClient() != null) {
+            wpeView.getSurfaceClient().addCallback(wpeView, new HolderCallback(this));
+        } else {
+            SurfaceHolder holder = getHolder();
+            Log.d(LOGTAG, "View: holder " + holder);
+            holder.addCallback(new HolderCallback(this));
+        }
 
         mScaleDetector = new ScaleGestureDetector(context, new ScaleListener());
 

--- a/wpe/src/main/java/com/wpe/wpeview/SurfaceClient.java
+++ b/wpe/src/main/java/com/wpe/wpeview/SurfaceClient.java
@@ -1,0 +1,18 @@
+package com.wpe.wpeview;
+
+import android.view.SurfaceHolder;
+
+public interface SurfaceClient {
+    /**
+     * Notify the host application to add a callback used to process Surface creation and update events.
+     * @param view The WPEView that initiated the callback.
+     * @param callback The SurfaceHolder.Callback2 to let the host application send Surface creation and update events.
+     */
+    void addCallback(WPEView view, SurfaceHolder.Callback2 callback);
+    /**
+     * Notify the host application to remove a callback,
+     * @param view The WPEView that initiated the callback.
+     * @param callback A SurfaceHolder.Callback2 to be removed.
+     */
+    void removeCallback(WPEView view, SurfaceHolder.Callback2 callback);
+}

--- a/wpe/src/main/java/com/wpe/wpeview/WPEView.java
+++ b/wpe/src/main/java/com/wpe/wpeview/WPEView.java
@@ -32,6 +32,7 @@ public class WPEView extends FrameLayout implements ViewObserver {
 
     private WebChromeClient m_chromeClient;
     private WPEViewClient m_wpeViewClient;
+    private SurfaceClient m_surfaceClient;
     private int m_currentLoadProgress = 0;
     private String m_title = "about:blank";
     private String m_url = "about:blank";
@@ -94,6 +95,14 @@ public class WPEView extends FrameLayout implements ViewObserver {
         Log.v(LOGTAG, "View ready " + getChildCount());
         // FIXME: Once PSON is enabled we may want to do something smarter here and not
         //        display the view until this point.
+        post(new Runnable() {
+            @Override
+            public void run() {
+                if (m_wpeViewClient != null) {
+                    m_wpeViewClient.onViewReady(WPEView.this);
+                }
+            }
+        });
     }
 
     @Override
@@ -320,5 +329,25 @@ public class WPEView extends FrameLayout implements ViewObserver {
     @Nullable
     public WPEViewClient getWPEViewClient() {
         return m_wpeViewClient;
+    }
+
+    /**
+     * Set the SurfaceClient that will manage the Surface where
+     * WPEView renders it's contents to. This will replace the current handler.
+     * @param client An implementation of SurfaceClient.
+     */
+    public void setSurfaceClient(@Nullable SurfaceClient client) {
+        m_surfaceClient = client;
+    }
+
+    /**
+     * Gets the SurfaceClient.
+     *
+     * @return the SurfaceClient, or {@code null} if not yet set
+     * @see #setSurfaceClient
+     */
+    @Nullable
+    public SurfaceClient getSurfaceClient() {
+        return m_surfaceClient;
     }
 }

--- a/wpe/src/main/java/com/wpe/wpeview/WPEViewClient.java
+++ b/wpe/src/main/java/com/wpe/wpeview/WPEViewClient.java
@@ -20,4 +20,9 @@ public interface WPEViewClient {
      * @param url The url of the page.
      */
     default void onPageFinished(WPEView view, String url) {}
+    /**
+     * Notify the host application that the internal SurfaceView has been created
+     * and it's ready to render to it's surface.
+     */
+    default void onViewReady(WPEView view) {}
 }


### PR DESCRIPTION
SurfaClient delegate allows host application to inject custom surfaces where WPEView renders it's contents to. For example this is used in VR in order to straight render to a swapChain surface instead of using the SurfaceHolder from the SurfaceView