### PR TITLE
Make sure folders are correctly created in ServiceUtils.copyFile

### DIFF
--- a/wpe/src/main/java/com/wpe/wpe/services/ServiceUtils.java
+++ b/wpe/src/main/java/com/wpe/wpe/services/ServiceUtils.java
@@ -38,8 +38,9 @@ public class ServiceUtils {
         OutputStream out = null;
         try {
             in = assetManager.open(filename);
-            String newFileName = context.getFilesDir() + "/" + filename;
-            out = new FileOutputStream(newFileName);
+            File newFile = new File(context.getFilesDir(), filename);
+            newFile.getParentFile().mkdirs();
+            out = new FileOutputStream(newFile, false);
             byte[] buffer = new byte[1024];
             int read;
             while ((read = in.read(buffer)) != -1) {


### PR DESCRIPTION
Fixes crash related to fontconfig:

2021-07-09 12:48:22.400 23795-23839/com.wpe.examples.minibrowser D/wpe-android: Fontconfig error: 
2021-07-09 12:48:22.400 23795-23839/com.wpe.examples.minibrowser D/wpe-android: Cannot load default config file: No such file: (null)
2021-07-09 12:48:22.400 23795-23839/com.wpe.examples.minibrowser D/wpe-android: --------- beginning of crash