### PR TITLE
Bump WPE WebKit to 2.34.1

### DIFF
--- a/scripts/bootstrap.py
+++ b/scripts/bootstrap.py
@@ -60,7 +60,7 @@ URL_TEMPLATE = "https://wpewebkit.org/android/bootstrap/{version}/{filename}"
 class Bootstrap:
     def __init__(self, args):
         # TODO: Allow passing a version string in the command line.
-        self.__version = '2.32.1'
+        self.__version = '2.34.1'
         self.__arch = args.arch
         self.__cerbero_path = args.cerbero
         self.__build = args.build


### PR DESCRIPTION
While the latest stable in the series is 2.34.6, there was already some work in the [Cerbero repository](https://github.com/Igalia/cerbero/) to get WebKit updated to 2.34.1 and it seemed better to complete that as a stepping stone before doing further updates 😉 

Prebuilts were already uploaded last week to https://wpewebkit.org/android/bootstrap/2.34.1/ (which is the new location used by the script after #52 was merged), produced from https://github.com/Igalia/cerbero/commit/a8625e4daba83da20f0841d528e657c0c180d43b

I did some smoke testing on a device running Android 11 and the Minibrowser is working as expected.