### PR TITLE
CI: Add GitHub actions configuration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,37 @@
+---
+
+name: CI build
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        api_level: [26, 29]
+        build_type: [Release, Debug]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Fetch WPE Bootstrap
+        run: |
+          python3 scripts/bootstrap.py -a arm64
+      - name: Java™ Setup
+        uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: 11
+      - name: Build Minibrowser
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: assembleMinApi${{ matrix.api_level }}${{ matrix.build_type }}
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+      - name: Save Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: minibrowser-api${{ matrix.api_level }}${{ matrix.build_type }}
+          path: examples/minibrowser/build/outputs/apk/minApi${{ matrix.api_level }}/**/*.apk

--- a/scripts/bootstrap.py
+++ b/scripts/bootstrap.py
@@ -99,13 +99,17 @@ class Bootstrap:
 
     def __fetch_binary(self, filename):
         from urllib.request import urlretrieve
+        import sys
 
         url = URL_TEMPLATE.format(version=self.__version, filename=filename)
 
-        def report(count, block_size, total_size):
-            size = total_size / 1024 / 1024
-            percent = int(100 * count * block_size / total_size)
-            print(f"\r  {url} [{size:.2f} MiB] {percent}% ", flush=True, end="")
+        if os.isatty(sys.stdout.fileno()):
+            def report(count, block_size, total_size):
+                size = total_size / 1024 / 1024
+                percent = int(100 * count * block_size / total_size)
+                print(f"\r  {url} [{size:.2f} MiB] {percent}% ", flush=True, end="")
+        else:
+            report = None
 
         print(f"  {url} ...", flush=True, end="")
         urlretrieve(url , filename, reporthook=report)


### PR DESCRIPTION
This adds configuration for GitHub actions to build the project on PRs and store the resulting Minibrowser APKs as artifacts.

For now the build uses prebuilt bootsrap packages—figuring out how to automate building those would be a different task 😉 