### PR TITLE
Bump WPE WebKit to 2.34.6

### DIFF
--- a/scripts/bootstrap.py
+++ b/scripts/bootstrap.py
@@ -60,7 +60,7 @@ URL_TEMPLATE = "https://wpewebkit.org/android/bootstrap/{version}/{filename}"
 class Bootstrap:
     def __init__(self, args):
         # TODO: Allow passing a version string in the command line.
-        self.__version = '2.34.1'
+        self.__version = '2.34.6'
         self.__arch = args.arch
         self.__cerbero_path = args.cerbero
         self.__build = args.build


### PR DESCRIPTION
SSIA.

I have uploaded fresh packages to https://wpewebkit.org/android/bootstrap/2.34.6/ as well. Version `2.34.6-20220329A` includes also the changes from https://github.com/Igalia/cerbero/pull/11 so I suppose @zhani may want this PR merged before #57 😉 