### PR TITLE
Improve bootstrap.py script compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ wpe/src/main/assets/gio
 *.swp
 __pycache__
 /cerbero
+.vscode/

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
     ext.kotlin_version = "1.3.72"
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.3'
@@ -17,7 +17,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/scripts/bootstrap.py
+++ b/scripts/bootstrap.py
@@ -1,4 +1,4 @@
-#!/bin/python
+#!/usr/bin/env python3
 
 """
 This script takes care of fetching, building and installing all WPE Android dependencies,
@@ -233,7 +233,7 @@ class Bootstrap:
         soname_list = []
         needed_list = []
 
-        p = subprocess.Popen(["readelf", "-d", lib_path], stdout=subprocess.PIPE)
+        p = subprocess.Popen(["readelf", "-d", lib_path], stdout=subprocess.PIPE, env=dict(os.environ, LC_ALL="C"))
         (stdout, stderr) = p.communicate()
 
         for line in stdout.decode().splitlines():


### PR DESCRIPTION
- change shebang to correctly call python3 on old systems which are
using python2 as default

- force using LC_ALL=C when calling readelf in order to have regex
working on non-english systems