### PR TITLE
Implement process spawn hooks in Android layer

### DIFF
--- a/wpe/CMakeLists.txt
+++ b/wpe/CMakeLists.txt
@@ -57,6 +57,7 @@ include_directories(
 
 add_library(WPEBrowserGlue SHARED
         src/main/glue/common/jnihelper.h
+        src/main/glue/common/jnihelper.cpp
         src/main/glue/browser/pageeventobserver.cpp
         src/main/glue/browser/entrypoints.cpp
         src/main/glue/browser/browser.cpp

--- a/wpe/src/main/glue/common/jnihelper.h
+++ b/wpe/src/main/glue/common/jnihelper.h
@@ -2,6 +2,16 @@
 
 #include <jni.h>
 
+namespace wpe {
+namespace android {
+
+void InitVM(JavaVM* vm);
+
+JNIEnv* AttachCurrentThread();
+
+} // namespace android
+} // namespace wpe
+
 static bool getJniEnv(JavaVM *vm, JNIEnv **env) {
     bool didAttachThread = false;
     *env = nullptr;
@@ -42,3 +52,4 @@ private:
     JavaVM *vm;
     JNIEnv *env;
 };
+

--- a/wpe/src/main/glue/networkprocess/entrypoints.cpp
+++ b/wpe/src/main/glue/networkprocess/entrypoints.cpp
@@ -59,6 +59,6 @@ jint JNI_OnLoad (JavaVM * vm, void *reserved)
     // TODO: Instead of explicitly exporting native methods, register them using registerNativeMethods
     //       which is recommended in https://developer.android.com/training/articles/perf-jni.html
 
-    return JNI_VERSION_1_4;
+    return JNI_VERSION_1_6;
 }
 

--- a/wpe/src/main/glue/webprocess/entrypoints.cpp
+++ b/wpe/src/main/glue/webprocess/entrypoints.cpp
@@ -95,6 +95,6 @@ jint JNI_OnLoad (JavaVM * vm, void *reserved)
     // TODO: Instead of explicitly exporting native methods, register them using registerNativeMethods
     //       which is recommended in https://developer.android.com/training/articles/perf-jni.html
 
-    return JNI_VERSION_1_4;
+    return JNI_VERSION_1_6;
 }
 


### PR DESCRIPTION
- Also do proper casts that are required for emulator to work
- Change JNI version to 1.6
- Use weak global ref when storing peer value because jenv and
  jobject refs are only valid during the call

Depends on https://github.com/Igalia/cerbero/pull/13
Required for #13 