### PR TITLE
Enable builds targeting armv7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         api_level: [26, 29]
         build_type: [Release, Debug]
-        target_abi: [X86, Arm64]
+        target_abi: [X86, Arm64, Armv7]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ python3 ./scripts/bootstrap.py --build --debug
 ```
 
 Finally, the bootstrap option accepts the `--arch` option to set the target architecture. 
-Currently supported architectures are `arm64` and `x86`.
+Currently supported architectures are `arm64`, `armv7`, and `x86`.
 
 
 ### Android Studio
@@ -84,5 +84,5 @@ Once the bootstrap process is done and all the dependencies are cross-compiled a
 you should be able to open the `launcher` demo with Android Studio and run it on a real device.
 
 ## Known issues and limitations
-* Only two architectures are supported at the moment `arm64` and `x86`.
+* The only architectures supported at the moment are `arm64`, `armv7`, and `x86`.
 * The scripts and build have only been tested in Linux.

--- a/examples/minibrowser/build.gradle
+++ b/examples/minibrowser/build.gradle
@@ -53,6 +53,13 @@ android {
                 abiFilter 'arm64-v8a'
             }
         }
+
+        armv7 {
+            dimension "abi"
+            ndk {
+                abiFilter 'armeabi-v7a'
+            }
+        }
     }
 }
 

--- a/scripts/bootstrap.py
+++ b/scripts/bootstrap.py
@@ -340,7 +340,7 @@ class Bootstrap:
 
         if self.__arch == 'arm64':
             android_abi = 'arm64-v8a'
-        elif self.__arch == 'arm':
+        elif self.__arch == 'armv7':
             android_abi = 'armeabi-v7a'
         elif self.__arch == 'x86':
             android_abi = 'x86'
@@ -394,7 +394,7 @@ if __name__ == "__main__":
         description='This script sets the dev environment up'
     )
 
-    parser.add_argument('-a', '--arch', metavar='architecture', required=False, default='arm64', choices=['arm64', 'x86'], help='The target architecture')
+    parser.add_argument('-a', '--arch', metavar='architecture', required=False, default='arm64', choices=['arm64', 'armv7', 'x86'], help='The target architecture')
     parser.add_argument('-c', '--cerbero', required=False, help='Path to the Cerbero checkout containing a completed build')
     parser.add_argument('-d', '--debug', required=False, action='store_true', help='Build the binaries with debug symbols')
     parser.add_argument('-b', '--build', required=False, action='store_true', help='Build dependencies instead of fetching the prebuilt binaries from the network')

--- a/wpe/build.gradle
+++ b/wpe/build.gradle
@@ -51,6 +51,13 @@ android {
                 abiFilter 'arm64-v8a'
             }
         }
+
+        armv7 {
+            dimension "abi"
+            ndk {
+                abiFilter 'armeabi-v7a'
+            }
+        }
     }
 
     externalNativeBuild {
@@ -63,7 +70,7 @@ android {
         abi {
             enable true
             reset()
-            include "x86", "arm64-v8a"
+            include "x86", "arm64-v8a", "armeabi-v7a"
             universalApk false
         }
     }


### PR DESCRIPTION
Assuming that Cerbero has already been successfully used to build ARMv7 bootstrap packages:

```sh
./scripts/bootstrap.py -a armv7 -c ../cerbero
```