### PR TITLE
Refactoring of native code

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+indent_style = space
+indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 *.iml
 .gradle
 /local.properties
-/.idea
+/.idea/*
+!/.idea/codeStyles/
 .DS_Store
 /build
 /captures

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,195 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <option name="AUTODETECT_INDENTS" value="false" />
+    <option name="LINE_SEPARATOR" value="&#10;" />
+    <option name="RIGHT_MARGIN" value="120" />
+    <option name="SOFT_MARGINS" value="120" />
+    <JavaCodeStyleSettings>
+      <option name="BLANK_LINES_AROUND_INITIALIZER" value="0" />
+      <option name="ENABLE_JAVADOC_FORMATTING" value="false" />
+      <option name="JD_ALIGN_PARAM_COMMENTS" value="false" />
+      <option name="JD_ALIGN_EXCEPTION_COMMENTS" value="false" />
+      <option name="JD_DO_NOT_WRAP_ONE_LINE_COMMENTS" value="true" />
+    </JavaCodeStyleSettings>
+    <JetCodeStyleSettings>
+      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
+    </JetCodeStyleSettings>
+    <Objective-C>
+      <option name="INDENT_NAMESPACE_MEMBERS" value="0" />
+      <option name="KEEP_STRUCTURES_IN_ONE_LINE" value="true" />
+      <option name="KEEP_NESTED_NAMESPACES_IN_ONE_LINE" value="true" />
+      <option name="FUNCTION_BRACE_PLACEMENT" value="2" />
+      <option name="SPACE_WITHIN_TEMPLATE_DOUBLE_GT" value="false" />
+      <option name="SPACE_BEFORE_INIT_LIST" value="true" />
+      <option name="SPACE_BEFORE_POINTER_IN_DECLARATION" value="false" />
+      <option name="SPACE_AFTER_POINTER_IN_DECLARATION" value="true" />
+      <option name="SPACE_BEFORE_REFERENCE_IN_DECLARATION" value="false" />
+      <option name="SPACE_AFTER_REFERENCE_IN_DECLARATION" value="true" />
+      <option name="SPACE_AFTER_DICTIONARY_LITERAL_COLON" value="false" />
+    </Objective-C>
+    <codeStyleSettings language="CMake">
+      <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+    </codeStyleSettings>
+    <codeStyleSettings language="Groovy">
+      <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
+      <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+      <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="1" />
+      <option name="BLANK_LINES_AROUND_METHOD_IN_INTERFACE" value="0" />
+      <option name="CLASS_BRACE_STYLE" value="2" />
+      <option name="METHOD_BRACE_STYLE" value="2" />
+      <option name="SPACE_WITHIN_ARRAY_INITIALIZER_BRACES" value="true" />
+      <option name="SPACE_AFTER_TYPE_CAST" value="false" />
+      <option name="SPACE_BEFORE_ARRAY_INITIALIZER_LBRACE" value="true" />
+      <option name="KEEP_SIMPLE_BLOCKS_IN_ONE_LINE" value="true" />
+    </codeStyleSettings>
+    <codeStyleSettings language="JAVA">
+      <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
+      <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+      <option name="KEEP_BLANK_LINES_BETWEEN_PACKAGE_DECLARATION_AND_HEADER" value="1" />
+      <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="1" />
+      <option name="BLANK_LINES_AROUND_METHOD" value="0" />
+      <option name="BLANK_LINES_AROUND_METHOD_IN_INTERFACE" value="0" />
+      <option name="CLASS_BRACE_STYLE" value="2" />
+      <option name="METHOD_BRACE_STYLE" value="2" />
+      <option name="INDENT_CASE_FROM_SWITCH" value="false" />
+      <option name="SPACE_WITHIN_ARRAY_INITIALIZER_BRACES" value="true" />
+      <option name="SPACE_AFTER_TYPE_CAST" value="false" />
+      <option name="SPACE_BEFORE_ARRAY_INITIALIZER_LBRACE" value="true" />
+      <option name="KEEP_SIMPLE_BLOCKS_IN_ONE_LINE" value="true" />
+      <option name="KEEP_SIMPLE_METHODS_IN_ONE_LINE" value="true" />
+      <option name="KEEP_SIMPLE_LAMBDAS_IN_ONE_LINE" value="true" />
+      <option name="KEEP_SIMPLE_CLASSES_IN_ONE_LINE" value="true" />
+      <option name="WRAP_COMMENTS" value="true" />
+    </codeStyleSettings>
+    <codeStyleSettings language="ObjectiveC">
+      <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
+      <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+      <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="1" />
+      <option name="BLANK_LINES_AROUND_METHOD" value="0" />
+      <option name="BLANK_LINES_AROUND_METHOD_IN_INTERFACE" value="0" />
+      <option name="CLASS_BRACE_STYLE" value="2" />
+      <option name="INDENT_CASE_FROM_SWITCH" value="false" />
+      <option name="SPACE_WITHIN_ARRAY_INITIALIZER_BRACES" value="true" />
+      <option name="SPACE_AFTER_TYPE_CAST" value="false" />
+    </codeStyleSettings>
+    <codeStyleSettings language="XML">
+      <option name="FORCE_REARRANGE_MODE" value="1" />
+      <indentOptions>
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      </indentOptions>
+      <arrangement>
+        <rules>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>xmlns:android</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>xmlns:.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:id</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:name</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>name</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>style</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>ANDROID_ATTRIBUTE_ORDER</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>.*</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+        </rules>
+      </arrangement>
+    </codeStyleSettings>
+    <codeStyleSettings language="kotlin">
+      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
+      <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
+      <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+      <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="1" />
+    </codeStyleSettings>
+  </code_scheme>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.3.72"
+    ext.kotlin_version = '1.3.72'
     repositories {
         google()
         mavenCentral()
@@ -8,9 +8,6 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
     }
 }
 

--- a/examples/minibrowser/build.gradle
+++ b/examples/minibrowser/build.gradle
@@ -1,18 +1,19 @@
 plugins {
     id 'com.android.application'
     id 'kotlin-android'
+    id 'kotlin-android-extensions'
 }
 
 android {
     compileSdkVersion 30
-    buildToolsVersion "30.0.3"
+    buildToolsVersion '30.0.3'
 
     defaultConfig {
-        applicationId "com.wpe.examples.minibrowser"
+        applicationId 'com.wpe.examples.minibrowser'
         minSdkVersion 26
         targetSdkVersion 30
         versionCode 1
-        versionName "1.0"
+        versionName '1.0'
     }
 
     buildTypes {
@@ -21,57 +22,57 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+
     kotlinOptions {
         jvmTarget = '1.8'
     }
 
-    flavorDimensions "api", "abi"
+    flavorDimensions 'api', 'abi'
     productFlavors {
         minApi26 {
-            dimension "api"
+            dimension 'api'
             minSdkVersion 26
         }
+
         minApi29 {
-            dimension "api"
+            dimension 'api'
             minSdkVersion 29
         }
 
         x86 {
-            dimension "abi"
+            dimension 'abi'
             ndk {
-                abiFilter 'x86'
+                abiFilters 'x86'
             }
         }
 
         arm64 {
-            dimension "abi"
+            dimension 'abi'
             ndk {
-                abiFilter 'arm64-v8a'
+                abiFilters 'arm64-v8a'
             }
         }
 
         armv7 {
-            dimension "abi"
+            dimension 'abi'
             ndk {
-                abiFilter 'armeabi-v7a'
+                abiFilters 'armeabi-v7a'
             }
         }
     }
 }
 
 dependencies {
-    implementation project(":wpe")
+    implementation project(':wpe')
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'androidx.core:core-ktx:1.3.2'
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'com.google.android.material:material:1.3.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
-    implementation "androidx.fragment:fragment-ktx:1.3.2"
-    apply plugin: 'com.android.application'
-    apply plugin: 'kotlin-android'
-    apply plugin: 'kotlin-android-extensions'
+    implementation 'androidx.fragment:fragment-ktx:1.3.2'
 }

--- a/examples/minibrowser/src/main/AndroidManifest.xml
+++ b/examples/minibrowser/src/main/AndroidManifest.xml
@@ -3,18 +3,22 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.wpe.examples.minibrowser">
 
-    <uses-feature android:name="android.hardware.touchscreen" android:required="false" />
-    <uses-feature android:name="android.software.leanback" android:required="false" />
+    <uses-feature
+        android:name="android.hardware.touchscreen"
+        android:required="false" />
+    <uses-feature
+        android:name="android.software.leanback"
+        android:required="false" />
 
     <application
-        android:debuggable="true"
         android:allowBackup="true"
+        android:banner="@drawable/banner"
+        android:debuggable="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.MiniBrowser"
-        android:banner="@drawable/banner"
         tools:ignore="HardcodedDebugMode">
         <activity
             android:name=".MainActivity"

--- a/examples/minibrowser/src/main/java/com/wpe/examples/minibrowser/Browser.kt
+++ b/examples/minibrowser/src/main/java/com/wpe/examples/minibrowser/Browser.kt
@@ -2,6 +2,7 @@ package com.wpe.examples.minibrowser
 
 import android.content.Context
 import android.content.res.Configuration
+import android.graphics.Color
 import android.os.Bundle
 import android.util.Log
 import android.view.KeyEvent
@@ -17,6 +18,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.os.bundleOf
 import androidx.fragment.app.add
 import androidx.fragment.app.commit
+import com.google.android.material.color.MaterialColors
 import com.wpe.wpeview.WPEView
 import com.wpe.wpeview.WPEViewClient
 import com.wpe.wpeview.WebChromeClient
@@ -47,7 +49,7 @@ class MainActivity : AppCompatActivity(R.layout.activity_main) {
     }
 
     internal fun newTab(url: String?) {
-        val charPool : List<Char> = ('a'..'z') + ('A'..'Z') + ('0'..'9')
+        val charPool: List<Char> = ('a'..'z') + ('A'..'Z') + ('0'..'9')
         val tabId = (1..12)
             .map { _ -> kotlin.random.Random.nextInt(0, charPool.size) }
             .map(charPool::get)
@@ -80,9 +82,9 @@ class MainActivity : AppCompatActivity(R.layout.activity_main) {
             setUrl(null)
         }
 
-        val tab = supportFragmentManager.findFragmentByTag(tab.tab.tag) ?: return
+        val tab2 = supportFragmentManager.findFragmentByTag(tab.tab.tag) ?: return
         supportFragmentManager.commit {
-            remove(tab)
+            remove(tab2)
         }
     }
 
@@ -91,13 +93,13 @@ class MainActivity : AppCompatActivity(R.layout.activity_main) {
         activeTabItem = item
         setUrl(activeTab?.view?.url)
         supportFragmentManager.commit {
-           for (fragment in supportFragmentManager.fragments) {
-               if (fragment == activeTab) {
-                   show(fragment)
-               } else {
-                   hide(fragment)
-               }
-           }
+            for (fragment in supportFragmentManager.fragments) {
+                if (fragment == activeTab) {
+                    show(fragment)
+                } else {
+                    hide(fragment)
+                }
+            }
         }
     }
 
@@ -175,8 +177,19 @@ class MainActivity : AppCompatActivity(R.layout.activity_main) {
         activeTab?.view?.canGoForward()?.let { menu?.findItem(R.id.action_forward)?.setEnabled(it) }
         return super.onPrepareOptionsMenu(menu)
     }
+
     override fun onCreateOptionsMenu(menu: Menu?): Boolean {
         menuInflater.inflate(R.menu.actions, menu)
+
+        // FIXME: There is a bug with androidx.appcompat 1.2.0 that doesn't take into account
+        // the android:iconTint attribute in actions.xml menu description. So, we need to force
+        // the tint color here by code to apply it visually. Normally this bug should be fixed
+        // by upgrading the androidx.appcompat dependency, then this block of code should be removed.
+        val item = menu?.findItem(R.id.action_tab)
+        val icon = item?.icon
+        icon?.setTint(MaterialColors.getColor(this, R.attr.colorOnPrimary, Color.BLACK))
+        item?.icon = icon
+
         return super.onCreateOptionsMenu(menu)
     }
 
@@ -220,9 +233,6 @@ class MainActivity : AppCompatActivity(R.layout.activity_main) {
     }
 
     fun onCommit(text: String) {
-        if (text == null) {
-            return;
-        }
         var url: String = if ((text.contains(".") || text.contains(":")) && !text.contains(" ")) {
             text
         } else {

--- a/examples/minibrowser/src/main/java/com/wpe/examples/minibrowser/TabsSelector.kt
+++ b/examples/minibrowser/src/main/java/com/wpe/examples/minibrowser/TabsSelector.kt
@@ -11,6 +11,7 @@ import android.widget.BaseAdapter
 import android.widget.ImageView
 import android.widget.TextView
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import com.google.android.material.color.MaterialColors
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import kotlinx.android.synthetic.main.tabs_selector.*
 
@@ -19,7 +20,11 @@ class TabsSelector(tabs: ArrayList<TabSelectorItem>, active: Int) : BottomSheetD
     private val tabs: ArrayList<TabSelectorItem> = tabs
     internal var selected: Int = active
 
-    private class TabsListAdapter(parent: BottomSheetDialogFragment, context: Context, tabs: ArrayList<TabSelectorItem>) : BaseAdapter() {
+    private class TabsListAdapter(
+        parent: BottomSheetDialogFragment,
+        context: Context,
+        tabs: ArrayList<TabSelectorItem>
+    ) : BaseAdapter() {
         private val bottomSheet: BottomSheetDialogFragment = parent
         private val context: Context = context
         private val tabs: ArrayList<TabSelectorItem> = tabs
@@ -55,7 +60,7 @@ class TabsSelector(tabs: ArrayList<TabSelectorItem>, active: Int) : BottomSheetD
             }
 
             if (position == (bottomSheet as TabsSelector).selected) {
-                row.setBackgroundColor(Color.parseColor("#defaf3"))
+                row.setBackgroundColor(MaterialColors.getColor(context, R.attr.colorSecondary, Color.GRAY))
             }
 
             return row
@@ -85,7 +90,7 @@ class TabsSelector(tabs: ArrayList<TabSelectorItem>, active: Int) : BottomSheetD
         super.onActivityCreated(savedInstanceState)
 
         tabsList.adapter = TabsListAdapter(this, requireContext(), tabs)
-        tabsList.onItemClickListener = AdapterView.OnItemClickListener { parent, view, position, id ->
+        tabsList.onItemClickListener = AdapterView.OnItemClickListener { _, _, position, _ ->
             selected = position
             val adapter = (tabsList.adapter as BaseAdapter);
             adapter.notifyDataSetChanged()

--- a/examples/minibrowser/src/main/res/layout/activity_main.xml
+++ b/examples/minibrowser/src/main/res/layout/activity_main.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/main"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -12,7 +10,7 @@
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="?android:actionBarSize"
-        android:background="@color/white">
+        android:background="?android:statusBarColor">
 
         <EditText
             android:id="@+id/location_view"
@@ -33,11 +31,12 @@
         android:layout_height="3dp"
         android:layout_alignBottom="@id/toolbar" />
 
-    <androidx.fragment.app.FragmentContainerView xmlns:android="http://schemas.android.com/apk/res/android"
+    <androidx.fragment.app.FragmentContainerView
         android:id="@+id/fragment_container_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_below="@id/toolbar"
         android:focusable="true"
         android:focusableInTouchMode="true" />
+
 </RelativeLayout>

--- a/examples/minibrowser/src/main/res/layout/tab_fragment.xml
+++ b/examples/minibrowser/src/main/res/layout/tab_fragment.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android" android:layout_width="match_parent"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
     android:layout_height="match_parent">
 
     <com.wpe.wpeview.WPEView
@@ -8,6 +8,6 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:focusable="true"
-        android:focusableInTouchMode="true"/>
+        android:focusableInTouchMode="true" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/examples/minibrowser/src/main/res/layout/tabs_selector.xml
+++ b/examples/minibrowser/src/main/res/layout/tabs_selector.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/tab_wrapper"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -12,11 +10,10 @@
         android:id="@+id/tabsList"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:paddingBottom="100dp"
         android:clipToPadding="false"
-        android:scrollbarStyle="outsideOverlay"
-        android:drawSelectorOnTop="true">
-    </ListView>
+        android:drawSelectorOnTop="true"
+        android:paddingBottom="100dp"
+        android:scrollbarStyle="outsideOverlay" />
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/newTabButton"

--- a/examples/minibrowser/src/main/res/layout/tabs_selector_row.xml
+++ b/examples/minibrowser/src/main/res/layout/tabs_selector_row.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -12,12 +10,11 @@
         android:layout_height="wrap_content"
         android:layout_marginLeft="10dp"
         android:layout_marginTop="10dp"
-        android:textColor="#000000"
+        android:ellipsize="end"
+        android:maxEms="18"
+        android:singleLine="true"
         android:textSize="16sp"
         android:textStyle="bold"
-        android:ellipsize="end"
-        android:singleLine="true"
-        android:maxEms="18"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
@@ -27,8 +24,8 @@
         android:layout_height="wrap_content"
         android:layout_marginBottom="10dp"
         android:ellipsize="end"
-        android:singleLine="true"
         android:maxEms="18"
+        android:singleLine="true"
         app:layout_constraintStart_toStartOf="@+id/tabTitle"
         app:layout_constraintTop_toBottomOf="@+id/tabTitle" />
 
@@ -36,11 +33,13 @@
         android:id="@+id/closeButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="18dp"
-        android:layout_marginEnd="4dp"
+        android:layout_marginTop="20dp"
+        android:layout_marginEnd="8dp"
+        android:background="@android:color/transparent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:srcCompat="@drawable/baseline_close_black_20" />
+        app:srcCompat="@drawable/baseline_close_black_20"
+        app:tint="?attr/colorOnPrimary" />
 
     <View
         android:id="@+id/divider"

--- a/examples/minibrowser/src/main/res/menu/actions.xml
+++ b/examples/minibrowser/src/main/res/menu/actions.xml
@@ -4,22 +4,23 @@
     <item
         android:id="@+id/action_tab"
         android:icon="@drawable/tabs_icon_black_18"
+        android:iconTint="?attr/colorOnPrimary"
         android:title="Tabs"
-        app:showAsAction="always"/>
+        app:showAsAction="always" />
     <item
         android:id="@+id/action_back"
         android:title="@string/action_back"
-        app:showAsAction="never"/>
+        app:showAsAction="never" />
     <item
         android:id="@+id/action_forward"
         android:title="@string/action_forward"
-        app:showAsAction="never"/>
+        app:showAsAction="never" />
     <item
         android:id="@+id/action_stop"
         android:title="@string/action_stop"
-        app:showAsAction="never"/>
+        app:showAsAction="never" />
     <item
         android:id="@+id/action_reload"
         android:title="@string/action_reload"
-        app:showAsAction="never"/>
+        app:showAsAction="never" />
 </menu>

--- a/examples/minibrowser/src/main/res/values-night/themes.xml
+++ b/examples/minibrowser/src/main/res/values-night/themes.xml
@@ -3,12 +3,12 @@
     <style name="Theme.MiniBrowser" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/purple_200</item>
-        <item name="colorPrimaryVariant">@color/purple_700</item>
-        <item name="colorOnPrimary">@color/black</item>
+        <item name="colorPrimaryVariant">@color/purple_500</item>
+        <item name="colorOnPrimary">@color/white</item>
         <!-- Secondary brand color. -->
-        <item name="colorSecondary">@color/teal_200</item>
-        <item name="colorSecondaryVariant">@color/teal_200</item>
-        <item name="colorOnSecondary">@color/black</item>
+        <item name="colorSecondary">@color/teal_700</item>
+        <item name="colorSecondaryVariant">@color/teal_700</item>
+        <item name="colorOnSecondary">@color/white</item>
         <!-- Status bar color. -->
         <item name="android:statusBarColor" tools:targetApi="l">?attr/colorPrimaryVariant</item>
         <!-- Customize your theme here. -->

--- a/examples/minibrowser/src/main/res/values/colors.xml
+++ b/examples/minibrowser/src/main/res/values/colors.xml
@@ -2,9 +2,8 @@
 <resources>
     <color name="purple_200">#FFBB86FC</color>
     <color name="purple_500">#FF6200EE</color>
-    <color name="purple_700">#FF3700B3</color>
     <color name="teal_200">#FF03DAC5</color>
     <color name="teal_700">#FF018786</color>
-    <color name="black">#FF000000</color>
-    <color name="white">#FFFFFFFF</color>
+    <color name="black">#FF0F0F0F</color>
+    <color name="white">#FFF0F0F0</color>
 </resources>

--- a/examples/minibrowser/src/main/res/values/themes.xml
+++ b/examples/minibrowser/src/main/res/values/themes.xml
@@ -3,11 +3,11 @@
     <style name="Theme.MiniBrowser" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/purple_500</item>
-        <item name="colorPrimaryVariant">@color/purple_700</item>
-        <item name="colorOnPrimary">@color/white</item>
+        <item name="colorPrimaryVariant">@color/purple_200</item>
+        <item name="colorOnPrimary">@color/black</item>
         <!-- Secondary brand color. -->
         <item name="colorSecondary">@color/teal_200</item>
-        <item name="colorSecondaryVariant">@color/teal_700</item>
+        <item name="colorSecondaryVariant">@color/teal_200</item>
         <item name="colorOnSecondary">@color/black</item>
         <!-- Status bar color. -->
         <item name="android:statusBarColor" tools:targetApi="l">?attr/colorPrimaryVariant</item>

--- a/wpe/CMakeLists.txt
+++ b/wpe/CMakeLists.txt
@@ -55,9 +55,17 @@ include_directories(
         src/main/glue/common
 )
 
-add_library(WPEBrowserGlue SHARED
-        src/main/glue/common/jnihelper.h
+add_library(WPECommonGlue SHARED
         src/main/glue/common/jnihelper.cpp
+        src/main/glue/common/logging.cpp
+        )
+
+target_link_libraries(WPECommonGlue
+        ${android-lib}
+        ${log-lib}
+        )
+
+add_library(WPEBrowserGlue SHARED
         src/main/glue/browser/pageeventobserver.cpp
         src/main/glue/browser/entrypoints.cpp
         src/main/glue/browser/browser.cpp
@@ -79,6 +87,7 @@ target_link_libraries(WPEBrowserGlue
         libwpe-1.0
         WPEBackend-default
         WPEWebKit-1.0
+        WPECommonGlue
         )
 
 add_library(WPENetworkProcessGlue SHARED
@@ -88,6 +97,7 @@ add_library(WPENetworkProcessGlue SHARED
 target_link_libraries(WPENetworkProcessGlue
         ${log-lib}
         WPEWebKit-1.0
+        WPECommonGlue
         )
 
 add_library(WPEWebProcessGlue SHARED
@@ -102,4 +112,5 @@ target_link_libraries(WPEWebProcessGlue
         gmodule-2.0
         WPEBackend-default
         WPEWebKit-1.0
+        WPECommonGlue
         )

--- a/wpe/build.gradle
+++ b/wpe/build.gradle
@@ -4,16 +4,17 @@ plugins {
 
 android {
     compileSdkVersion 30
-    buildToolsVersion "30.0.3"
+    buildToolsVersion '30.0.3'
+    ndkVersion '23.1.7779620'
 
     defaultConfig {
         minSdkVersion 26
         targetSdkVersion 30
         versionCode 1
-        versionName "1.0"
+        versionName '1.0'
 
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-        consumerProguardFiles "consumer-rules.pro"
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
+        consumerProguardFiles 'consumer-rules.pro'
     }
 
     buildTypes {
@@ -22,47 +23,49 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    flavorDimensions "api", "abi"
+    flavorDimensions 'api', 'abi'
     productFlavors {
         minApi26 {
-            dimension "api"
+            dimension 'api'
             minSdkVersion 26
         }
+
         minApi29 {
-            dimension "api"
+            dimension 'api'
             minSdkVersion 29
         }
 
         x86 {
-            dimension "abi"
+            dimension 'abi'
             ndk {
-                abiFilter 'x86'
+                abiFilters 'x86'
             }
         }
 
         arm64 {
-            dimension "abi"
+            dimension 'abi'
             ndk {
-                abiFilter 'arm64-v8a'
+                abiFilters 'arm64-v8a'
             }
         }
 
         armv7 {
-            dimension "abi"
+            dimension 'abi'
             ndk {
-                abiFilter 'armeabi-v7a'
+                abiFilters 'armeabi-v7a'
             }
         }
     }
 
     externalNativeBuild {
         cmake {
-            path "CMakeLists.txt"
+            path 'CMakeLists.txt'
         }
     }
 
@@ -70,7 +73,7 @@ android {
         abi {
             enable true
             reset()
-            include "x86", "arm64-v8a", "armeabi-v7a"
+            include 'x86', 'arm64-v8a', 'armeabi-v7a'
             universalApk false
         }
     }
@@ -91,11 +94,11 @@ android {
                 def services = ""
                 for (int i = 0; i < NUMBER_OF_AUX_PROCESSES; i++) {
                     services += "\t\t<service\n" +
-                            "            android:name=\"com.wpe.wpe.services.WPEServices\$NetworkProcessService$i\"\n" +
-                            "            android:process=\":WPENetworkProcess$i\"/>\n" +
-                            "        <service\n" +
-                            "            android:name=\"com.wpe.wpe.services.WPEServices\$WebProcessService$i\"\n" +
-                            "            android:process=\":WPEWebProcess$i\"/>\n\n"
+                        "            android:name=\"com.wpe.wpe.services.WPEServices\$NetworkProcessService$i\"\n" +
+                        "            android:process=\":WPENetworkProcess$i\"/>\n" +
+                        "        <service\n" +
+                        "            android:name=\"com.wpe.wpe.services.WPEServices\$WebProcessService$i\"\n" +
+                        "            android:process=\":WPEWebProcess$i\"/>\n\n"
                 }
                 manifestContent = manifestContent.replace("<!-- SERVICES PLACEHOLDER -->", services)
 
@@ -115,7 +118,7 @@ android {
             def services = ""
             for (int i = 0; i < NUMBER_OF_AUX_PROCESSES; i++) {
                 services += "\tpublic static final class WebProcessService$i extends WebProcessService {}\n" +
-                        "\tpublic static final class NetworkProcessService$i extends NetworkProcessService {}\n"
+                    "\tpublic static final class NetworkProcessService$i extends NetworkProcessService {}\n"
             }
             templateFileContent = templateFileContent.replace("// SERVICES PLACEHOLDER", services)
 
@@ -130,7 +133,7 @@ android {
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'com.google.android.material:material:1.3.0'
-    implementation "androidx.annotation:annotation:1.1.0"
+    implementation 'androidx.annotation:annotation:1.1.0'
     testImplementation 'junit:junit:4.+'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'

--- a/wpe/src/main/AndroidManifest.xml
+++ b/wpe/src/main/AndroidManifest.xml
@@ -3,8 +3,10 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.wpe.wpe">
 
-    <uses-permission android:name="android.permission.INTERNET"/>
-    <application android:extractNativeLibs="true" android:debuggable="true"
+    <uses-permission android:name="android.permission.INTERNET" />
+    <application
+        android:debuggable="true"
+        android:extractNativeLibs="true"
         tools:ignore="HardcodedDebugMode">
 
         <!-- Do not remove this section. Service definition is generated at build time -->

--- a/wpe/src/main/glue/browser/browser.cpp
+++ b/wpe/src/main/glue/browser/browser.cpp
@@ -1,5 +1,8 @@
-#include <algorithm>
+#include "browser.h"
 
+#include "logging.h"
+
+#include <algorithm>
 #include <gio/gio.h>
 #include <glib.h>
 #include <glib-object.h>
@@ -7,58 +10,53 @@
 
 #include <wpe-android/view-backend-exportable.h>
 
-#include <jni.h>
 #include <android/hardware_buffer.h>
 #include <android/surface_control.h>
-
-#include "browser.h"
-#include "logging.h"
 
 #define PAGE_METHOD_PROXY(BROWSER_METHOD, PAGE_METHOD, PRIORITY) \
     void Browser::BROWSER_METHOD(int pageId) \
     { \
-        if (m_pages.find(pageId) == m_pages.end()) { \
+        if (m_pages.find(pageId) == m_pages.end()) \
             return; \
-        } \
-        g_main_context_invoke_full(*m_uiProcessThreadContext, PRIORITY, [](gpointer data) -> gboolean { \
-            auto *page = reinterpret_cast<Page*>(data); \
+        g_main_context_invoke_full(*m_uiProcessThreadContext, PRIORITY, +[](gpointer data) -> gboolean { \
+            auto* page = reinterpret_cast<Page*>(data); \
             if (page != nullptr) page->PAGE_METHOD(); \
             return G_SOURCE_REMOVE; \
-        }, m_pages[pageId].get(), NULL); \
+        }, m_pages[pageId].get(), nullptr); \
     }
 
 void Browser::init()
 {
     ALOGV("Browser::init");
 
-    if (!m_uiProcessThreadContext) {
+    if (!m_uiProcessThreadContext)
         m_uiProcessThreadContext = std::make_unique<GMainContext*>(g_main_context_new());
-    };
 
     runMainLoop();
 }
 
-void Browser::deinit()
+void Browser::shut()
 {
-    ALOGV("Browser::deinit");
+    ALOGV("Browser::shut");
 
     g_main_loop_quit(*m_uiProcessThreadLoop.get());
 }
 
-typedef struct {
-    void (*callback)(void*);
-    void* callbackData;
-    void (*destroy)(void*);
-} GenericCallback;
-
-void Browser::invoke(void (*callback)(void*), void* callbackData, void (*destroy)(void*))
+void Browser::invoke(void (* callback)(void*), void* callbackData, void (* destroy)(void*))
 {
+    struct GenericCallback
+    {
+        void (* callback)(void*);
+        void* callbackData;
+        void (* destroy)(void*);
+    };
+
     auto* data = new GenericCallback { callback, callbackData, destroy };
-    g_main_context_invoke_full(*m_uiProcessThreadContext, G_PRIORITY_DEFAULT, [](gpointer data) -> gboolean {
+    g_main_context_invoke_full(*m_uiProcessThreadContext, G_PRIORITY_DEFAULT, +[](gpointer data) -> gboolean {
         auto* genericData = reinterpret_cast<GenericCallback*>(data);
         genericData->callback(genericData->callbackData);
         return G_SOURCE_REMOVE;
-    }, data, [](gpointer data) -> void {
+    }, data, +[](gpointer data) -> void {
         auto* genericData = reinterpret_cast<GenericCallback*>(data);
         if (genericData->destroy)
             genericData->destroy(genericData->callbackData);
@@ -66,9 +64,10 @@ void Browser::invoke(void (*callback)(void*), void* callbackData, void (*destroy
     });
 }
 
-void Browser::runMainLoop() {
-    pipe_stdout_to_logcat();
-    enable_gst_debug();
+void Browser::runMainLoop()
+{
+    wpe::android::pipeStdoutToLogcat();
+    wpe::android::enableGstDebug();
 
     ALOGV("ui_process_thread_entry -- entered, g_main_context_default() %p",
           g_main_context_default());
@@ -87,21 +86,21 @@ void Browser::runMainLoop() {
     g_main_context_pop_thread_default(*m_uiProcessThreadContext.get());
 
     g_main_loop_unref(*m_uiProcessThreadLoop.get());
-    m_uiProcessThreadLoop.reset(NULL);
+    m_uiProcessThreadLoop.reset(nullptr);
 }
 
 void Browser::newPage(int pageId, int width, int height, const std::string& userAgent,
-                        std::shared_ptr<PageEventObserver> observer)
+                      std::shared_ptr<PageEventObserver> observer)
 {
     ALOGV("Browser::newPage");
     auto page = std::make_unique<Page>(width, height, userAgent, observer);
-    g_main_context_invoke_full(*m_uiProcessThreadContext, G_PRIORITY_DEFAULT, [](gpointer data) -> gboolean {
-        auto *page = reinterpret_cast<Page*>(data);
-        if (page != nullptr) {
+    g_main_context_invoke_full(*m_uiProcessThreadContext, G_PRIORITY_DEFAULT, +[](gpointer data) -> gboolean {
+        auto* page = reinterpret_cast<Page*>(data);
+        if (page != nullptr)
             page->init();
-        }
+
         return G_SOURCE_REMOVE;
-    }, page.get(), NULL);
+    }, page.get(), nullptr);
 
     m_pages.insert(std::make_pair(pageId, std::move(page)));
 }
@@ -114,25 +113,25 @@ PAGE_METHOD_PROXY(reload, reload, G_PRIORITY_DEFAULT)
 PAGE_METHOD_PROXY(surfaceRedrawNeeded, surfaceRedrawNeeded, G_PRIORITY_DEFAULT)
 PAGE_METHOD_PROXY(surfaceDestroyed, surfaceDestroyed, G_PRIORITY_DEFAULT)
 
-struct SurfaceCreatedData {
-    Page* page;
-    ANativeWindow* window;
-};
-
 void Browser::surfaceCreated(int pageId, ANativeWindow* window)
 {
-    if (m_pages.find(pageId) == m_pages.end()) {
+    if (m_pages.find(pageId) == m_pages.end())
         return;
-    }
+
+    struct SurfaceCreatedData
+    {
+        Page* page;
+        ANativeWindow* window;
+    };
 
     auto* data = new SurfaceCreatedData { m_pages[pageId].get(), window };
-    g_main_context_invoke_full(*m_uiProcessThreadContext, G_PRIORITY_DEFAULT, [](gpointer data) -> gboolean {
+    g_main_context_invoke_full(*m_uiProcessThreadContext, G_PRIORITY_DEFAULT, +[](gpointer data) -> gboolean {
         auto* surfaceCreatedData = reinterpret_cast<SurfaceCreatedData*>(data);
         if (surfaceCreatedData->page != nullptr)
             surfaceCreatedData->page->surfaceCreated(surfaceCreatedData->window);
         surfaceCreatedData->window = nullptr;
         return G_SOURCE_REMOVE;
-    }, data, [](gpointer data) -> void {
+    }, data, +[](gpointer data) -> void {
         auto* surfaceCreatedData = reinterpret_cast<SurfaceCreatedData*>(data);
         if (surfaceCreatedData->window)
             ANativeWindow_release(surfaceCreatedData->window);
@@ -140,167 +139,168 @@ void Browser::surfaceCreated(int pageId, ANativeWindow* window)
     });
 }
 
-struct SurfaceChangedData {
-    Page* page;
-    int format;
-    int width;
-    int height;
-};
-
 void Browser::surfaceChanged(int pageId, int format, int width, int height)
 {
-    if (m_pages.find(pageId) == m_pages.end()) {
+    if (m_pages.find(pageId) == m_pages.end())
         return;
-    }
+
+    struct SurfaceChangedData
+    {
+        Page* page;
+        int format;
+        int width;
+        int height;
+    };
 
     auto* data = new SurfaceChangedData { m_pages[pageId].get(), format, width, height };
-    g_main_context_invoke_full(*m_uiProcessThreadContext, G_PRIORITY_DEFAULT, [](gpointer data) -> gboolean {
+    g_main_context_invoke_full(*m_uiProcessThreadContext, G_PRIORITY_DEFAULT, +[](gpointer data) -> gboolean {
         auto* surfaceChangedData = reinterpret_cast<SurfaceChangedData*>(data);
         if (surfaceChangedData->page != nullptr)
-            surfaceChangedData->page->surfaceChanged(surfaceChangedData->format, surfaceChangedData->width, surfaceChangedData->height);
+            surfaceChangedData->page->surfaceChanged(surfaceChangedData->format, surfaceChangedData->width,
+                                                     surfaceChangedData->height);
         return G_SOURCE_REMOVE;
-    }, data, [](gpointer data) -> void {
+    }, data, +[](gpointer data) -> void {
         delete reinterpret_cast<SurfaceChangedData*>(data);
     });
 }
-
-struct FrameOperation {
-    Page& page;
-    std::shared_ptr<ExportedBuffer> buffer;
-};
 
 void Browser::handleExportedBuffer(Page& page, std::shared_ptr<ExportedBuffer>&& exportedBuffer)
 {
     ALOGV("Browser::renderFrame() page %p, exportedBuffer %p", &page, exportedBuffer.get());
 
+    struct FrameOperation
+    {
+        Page& page;
+        std::shared_ptr<ExportedBuffer> buffer;
+    };
+
     auto* data = new FrameOperation { page, std::move(exportedBuffer) };
-    g_main_context_invoke_full(*m_uiProcessThreadContext, G_PRIORITY_DEFAULT, [](gpointer data) -> gboolean {
+    g_main_context_invoke_full(*m_uiProcessThreadContext, G_PRIORITY_DEFAULT, +[](gpointer data) -> gboolean {
         auto* frameOperation = reinterpret_cast<FrameOperation*>(data);
         frameOperation->page.handleExportedBuffer(frameOperation->buffer);
         return G_SOURCE_REMOVE;
-    }, data, [](gpointer data) -> void {
-        delete reinterpret_cast<FrameOperation *>(data);;
+    }, data, +[](gpointer data) -> void {
+        delete reinterpret_cast<FrameOperation*>(data);
     });
 }
 
-typedef struct {
-    Page* page;
-    char *url;
-} LoadUrlData;
-
-void Browser::loadUrl(int pageId, const char *urlData, jsize urlSize)
+void Browser::loadUrl(int pageId, const char* urlData, jsize urlSize)
 {
-    if (m_pages.find(pageId) == m_pages.end()) {
+    if (m_pages.find(pageId) == m_pages.end())
         return;
-    }
 
-    char *url = g_strndup(urlData, urlSize);
-    auto *data = new LoadUrlData { m_pages[pageId].get(), url };
-    g_main_context_invoke_full(*m_uiProcessThreadContext, G_PRIORITY_DEFAULT, [](gpointer data) -> gboolean {
-        auto *loadUrlData = reinterpret_cast<LoadUrlData *>(data);
-        if (loadUrlData->page != nullptr) {
+    struct LoadUrlData
+    {
+        Page* page;
+        char* url;
+    };
+
+    char* url = g_strndup(urlData, urlSize);
+    auto* data = new LoadUrlData { m_pages[pageId].get(), url };
+    g_main_context_invoke_full(*m_uiProcessThreadContext, G_PRIORITY_DEFAULT, +[](gpointer data) -> gboolean {
+        auto* loadUrlData = reinterpret_cast<LoadUrlData*>(data);
+        if (loadUrlData->page != nullptr)
             loadUrlData->page->loadUrl(loadUrlData->url);
-        }
         return G_SOURCE_REMOVE;
-    }, data, [](gpointer data) -> void {
-        auto *loadUrlData = reinterpret_cast<LoadUrlData*>(data);
+    }, data, +[](gpointer data) -> void {
+        auto* loadUrlData = reinterpret_cast<LoadUrlData*>(data);
         g_free(loadUrlData->url);
         delete loadUrlData;
     });
 }
 
-typedef struct {
-    Page* page;
-    wpe_input_touch_event_raw *touchEvent;
-} OnTouchData;
-
 void Browser::onTouch(int pageId, jlong time, jint type, jfloat x, jfloat y)
 {
-    if (m_pages.find(pageId) == m_pages.end()) {
+    if (m_pages.find(pageId) == m_pages.end())
         return;
-    }
 
     wpe_input_touch_event_type touchEventType = wpe_input_touch_event_type_null;
     switch (type) {
-        case 0:
-            touchEventType = wpe_input_touch_event_type_down;
-            break;
-        case 1:
-            touchEventType = wpe_input_touch_event_type_motion;
-            break;
-        case 2:
-            touchEventType = wpe_input_touch_event_type_up;
-            break;
+    case 0:
+        touchEventType = wpe_input_touch_event_type_down;
+        break;
+    case 1:
+        touchEventType = wpe_input_touch_event_type_motion;
+        break;
+    case 2:
+        touchEventType = wpe_input_touch_event_type_up;
+        break;
     }
 
-    struct wpe_input_touch_event_raw *touchEventRaw = g_new0(struct wpe_input_touch_event_raw, 1);
+    struct wpe_input_touch_event_raw* touchEventRaw = g_new0(struct wpe_input_touch_event_raw, 1);
     touchEventRaw->type = touchEventType;
-    touchEventRaw->time = (uint32_t) time;
+    touchEventRaw->time = (uint32_t)time;
     touchEventRaw->id = 0;
-    touchEventRaw->x = (int32_t) x;
-    touchEventRaw->y = (int32_t) y;
+    touchEventRaw->x = (int32_t)x;
+    touchEventRaw->y = (int32_t)y;
 
-    auto *data = new OnTouchData { m_pages[pageId].get(), touchEventRaw };
-    g_main_context_invoke_full(*m_uiProcessThreadContext, G_PRIORITY_DEFAULT, [](gpointer data) -> gboolean {
-        auto *touchData = reinterpret_cast<OnTouchData*>(data);
-        if (touchData->page != nullptr) {
+    struct OnTouchData
+    {
+        Page* page;
+        wpe_input_touch_event_raw* touchEvent;
+    };
+
+    auto* data = new OnTouchData { m_pages[pageId].get(), touchEventRaw };
+    g_main_context_invoke_full(*m_uiProcessThreadContext, G_PRIORITY_DEFAULT, +[](gpointer data) -> gboolean {
+        auto* touchData = reinterpret_cast<OnTouchData*>(data);
+        if (touchData->page != nullptr)
             touchData->page->onTouch(touchData->touchEvent);
-        }
         return G_SOURCE_REMOVE;
-    }, data, [](gpointer data) -> void {
-        auto *touchData = reinterpret_cast<OnTouchData*>(data);
+    }, data, +[](gpointer data) -> void {
+        auto* touchData = reinterpret_cast<OnTouchData*>(data);
         g_free(touchData->touchEvent);
         delete touchData;
     });
 }
 
-typedef struct {
-    Page* page;
-    double zoomLevel;
-} ZoomLevelData;
-
 void Browser::setZoomLevel(int pageId, jdouble zoomLevel)
 {
-    auto *data = new ZoomLevelData { m_pages[pageId].get(), zoomLevel };
-    g_main_context_invoke_full(*m_uiProcessThreadContext, G_PRIORITY_DEFAULT, [](gpointer data) -> gboolean {
-        auto *zoomLevelData = reinterpret_cast<ZoomLevelData*>(data);
-        if (zoomLevelData->page != nullptr) {
+    struct ZoomLevelData
+    {
+        Page* page;
+        double zoomLevel;
+    };
+
+    auto* data = new ZoomLevelData { m_pages[pageId].get(), zoomLevel };
+    g_main_context_invoke_full(*m_uiProcessThreadContext, G_PRIORITY_DEFAULT, +[](gpointer data) -> gboolean {
+        auto* zoomLevelData = reinterpret_cast<ZoomLevelData*>(data);
+        if (zoomLevelData->page != nullptr)
             zoomLevelData->page->setZoomLevel(zoomLevelData->zoomLevel);
-        }
         return G_SOURCE_REMOVE;
-    }, data, [](gpointer data) -> void {
+    }, data, +[](gpointer data) -> void {
         delete reinterpret_cast<ZoomLevelData*>(data);
     });
 }
 
-typedef struct {
+struct InputMethodContentData
+{
     Page* page;
     const char c;
     int offset;
-} InputMethodContentData;
+};
 
-void Browser::setInputMethodContent(int pageId, const char c) {
-    auto *data = new InputMethodContentData { m_pages[pageId].get(), c, 0 };
-    g_main_context_invoke_full(*m_uiProcessThreadContext, G_PRIORITY_DEFAULT, [](gpointer data) -> gboolean {
-        auto *data_ = static_cast<InputMethodContentData*>(data);
-        if (data_->page != nullptr) {
+void Browser::setInputMethodContent(int pageId, const char c)
+{
+    auto* data = new InputMethodContentData { m_pages[pageId].get(), c, 0 };
+    g_main_context_invoke_full(*m_uiProcessThreadContext, G_PRIORITY_DEFAULT, +[](gpointer data) -> gboolean {
+        auto* data_ = static_cast<InputMethodContentData*>(data);
+        if (data_->page != nullptr)
             data_->page->setInputMethodContent(data_->c);
-        }
         return G_SOURCE_REMOVE;
-    }, data, [](gpointer data) {
+    }, data, +[](gpointer data) {
         delete static_cast<InputMethodContentData*>(data);
     });
 }
 
-void Browser::deleteInputMethodContent(int pageId, int offset) {
-    auto *data = new InputMethodContentData { m_pages[pageId].get(), 0, offset };
-    g_main_context_invoke_full(*m_uiProcessThreadContext, G_PRIORITY_DEFAULT, [](gpointer data) -> gboolean {
-        auto *data_ = static_cast<InputMethodContentData*>(data);
-        if (data_->page != nullptr) {
+void Browser::deleteInputMethodContent(int pageId, int offset)
+{
+    auto* data = new InputMethodContentData { m_pages[pageId].get(), 0, offset };
+    g_main_context_invoke_full(*m_uiProcessThreadContext, G_PRIORITY_DEFAULT, +[](gpointer data) -> gboolean {
+        auto* data_ = static_cast<InputMethodContentData*>(data);
+        if (data_->page != nullptr)
             data_->page->deleteInputMethodContent(data_->offset);
-        }
         return G_SOURCE_REMOVE;
-    }, data, [](gpointer data) {
+    }, data, +[](gpointer data) {
         delete static_cast<InputMethodContentData*>(data);
     });
 }

--- a/wpe/src/main/glue/browser/exportedbuffer.h
+++ b/wpe/src/main/glue/browser/exportedbuffer.h
@@ -2,24 +2,23 @@
 
 #include <android/hardware_buffer.h>
 #include <memory>
-#include <stdint.h>
+#include <cstdint>
 
-struct ExportedBuffer : public std::enable_shared_from_this<ExportedBuffer> {
+struct ExportedBuffer final : public std::enable_shared_from_this<ExportedBuffer>
+{
     AHardwareBuffer* buffer;
 
     uint32_t poolID;
     uint32_t bufferID;
 
-    struct {
+    struct
+    {
         uint32_t width;
         uint32_t height;
     } size;
 
     ExportedBuffer(AHardwareBuffer* buffer, uint32_t poolID, uint32_t bufferID)
-        : buffer(buffer)
-        , poolID(poolID)
-        , bufferID(bufferID)
-        , size({ 0, 0 })
+            : buffer(buffer), poolID(poolID), bufferID(bufferID), size({ 0, 0 })
     {
         if (buffer) {
             AHardwareBuffer_acquire(buffer);

--- a/wpe/src/main/glue/browser/inputmethodcontext.cpp
+++ b/wpe/src/main/glue/browser/inputmethodcontext.cpp
@@ -1,27 +1,27 @@
 #include "inputmethodcontext.h"
+
 #include "logging.h"
 
-typedef enum
+enum InputMethodContextProperty
 {
     PROP_OBSERVER = 1,
     N_PROPERTIES
-} InputMethodContextProperty;
+};
 
-static GParamSpec *obj_properties[N_PROPERTIES] = { NULL, };
+static GParamSpec* obj_properties[N_PROPERTIES] = { nullptr, };
 
-typedef struct {
+struct InputMethodContextPrivate
+{
     PageEventObserver* m_observer;
-} InputMethodContextPrivate;
+};
 
 G_DEFINE_TYPE_WITH_PRIVATE(InputMethodContext, input_method_context, WEBKIT_TYPE_INPUT_METHOD_CONTEXT)
 
-#define PRIV(obj)                                                       \
-    ((InputMethodContextPrivate*) input_method_context_get_instance_private(WPE_ANDROID_INPUT_METHOD_CONTEXT(obj)))
+#define PRIV(obj) ((InputMethodContextPrivate*)input_method_context_get_instance_private(WPE_ANDROID_INPUT_METHOD_CONTEXT(obj)))
 
-static void
-input_method_context_notify_focus_in(WebKitInputMethodContext *context)
+static void input_method_context_notify_focus_in(WebKitInputMethodContext* context)
 {
-    InputMethodContextPrivate *priv = PRIV(context);
+    InputMethodContextPrivate* priv = PRIV(context);
     ALOGV("input_method_context_notify_focus_in %p", priv->m_observer);
 
     if (priv->m_observer != nullptr) {
@@ -29,10 +29,9 @@ input_method_context_notify_focus_in(WebKitInputMethodContext *context)
     }
 }
 
-static void
-input_method_context_notify_focus_out(WebKitInputMethodContext *context)
+static void input_method_context_notify_focus_out(WebKitInputMethodContext* context)
 {
-    InputMethodContextPrivate *priv = PRIV(context);
+    InputMethodContextPrivate* priv = PRIV(context);
     ALOGV("input_method_context_notify_focus_out %p", priv->m_observer);
 
     if (priv->m_observer != nullptr) {
@@ -41,85 +40,75 @@ input_method_context_notify_focus_out(WebKitInputMethodContext *context)
 }
 
 static void
-input_method_context_set_property(GObject      *object,
-                                  guint         property_id,
-                                  const GValue *value,
-                                  GParamSpec   *pspec)
+input_method_context_set_property(GObject* object, guint property_id, const GValue* value, GParamSpec* pspec)
 {
-    InputMethodContextPrivate *self = PRIV(object);
+    InputMethodContextPrivate* self = PRIV(object);
 
-    switch((InputMethodContextProperty) property_id) {
-        case PROP_OBSERVER:
-            self->m_observer = static_cast<PageEventObserver *>(g_value_get_pointer(value));
-            break;
-        default:
-            G_OBJECT_WARN_INVALID_PROPERTY_ID(object, property_id, pspec);
-            break;
+    switch ((InputMethodContextProperty)property_id) {
+    case PROP_OBSERVER:
+        self->m_observer = static_cast<PageEventObserver*>(g_value_get_pointer(value));
+        break;
+
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID(object, property_id, pspec);
+        break;
     }
 }
 
-static void
-input_method_context_get_property(GObject    *object,
-                                  guint       property_id,
-                                  GValue     *value,
-                                  GParamSpec *pspec)
+static void input_method_context_get_property(GObject* object, guint property_id, GValue* value, GParamSpec* pspec)
 {
-    InputMethodContextPrivate *self = PRIV(object);
+    InputMethodContextPrivate* self = PRIV(object);
 
-    switch((InputMethodContextProperty) property_id) {
-        case PROP_OBSERVER:
-            g_value_set_pointer(value, self->m_observer);
-            break;
-        default:
-            G_OBJECT_WARN_INVALID_PROPERTY_ID(object, property_id, pspec);
-            break;
+    switch ((InputMethodContextProperty)property_id) {
+    case PROP_OBSERVER:
+        g_value_set_pointer(value, self->m_observer);
+        break;
+
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID(object, property_id, pspec);
+        break;
     }
 }
 
-static void
-input_method_context_class_init(InputMethodContextClass *klass)
+static void input_method_context_class_init(InputMethodContextClass* klass)
 {
-    GObjectClass *object_class = G_OBJECT_CLASS(klass);
+    GObjectClass* object_class = G_OBJECT_CLASS(klass);
 
     object_class->set_property = input_method_context_set_property;
     object_class->get_property = input_method_context_get_property;
 
     obj_properties[PROP_OBSERVER] =
-        g_param_spec_pointer("observer",
-                             "Observer",
-                             "Page event observer",
-                             static_cast<GParamFlags>(G_PARAM_CONSTRUCT_ONLY | G_PARAM_READWRITE));
+            g_param_spec_pointer("observer",
+                                 "Observer",
+                                 "Page event observer",
+                                 static_cast<GParamFlags>(G_PARAM_CONSTRUCT_ONLY | G_PARAM_READWRITE));
 
     g_object_class_install_properties(object_class, N_PROPERTIES, obj_properties);
 
-    WebKitInputMethodContextClass *input_method_context_class = WEBKIT_INPUT_METHOD_CONTEXT_CLASS(klass);
-    //input_method_context_class->get_preedit = input_method_context_get_preedit;
+    WebKitInputMethodContextClass* input_method_context_class = WEBKIT_INPUT_METHOD_CONTEXT_CLASS(klass);
     input_method_context_class->notify_focus_in = input_method_context_notify_focus_in;
     input_method_context_class->notify_focus_out = input_method_context_notify_focus_out;
-    //input_method_context_class->notify_cursor_area = input_method_context_notify_cursor_area;
-    //input_method_context_class->notify_surrounding = input_method_context_notify_surrounding;
-    //input_method_context_class->reset = input_method_context_reset;
+
+    // input_method_context_class->get_preedit = input_method_context_get_preedit;
+    // input_method_context_class->notify_cursor_area = input_method_context_notify_cursor_area;
+    // input_method_context_class->notify_surrounding = input_method_context_notify_surrounding;
+    // input_method_context_class->reset = input_method_context_reset;
 }
 
-static void
-input_method_context_init(InputMethodContext *self)
-{
-}
+static void input_method_context_init(InputMethodContext* self)
+{}
 
-WebKitInputMethodContext*
-input_method_context_new(std::shared_ptr<PageEventObserver> observer)
+WebKitInputMethodContext* input_method_context_new(std::shared_ptr<PageEventObserver> observer)
 {
     return WEBKIT_INPUT_METHOD_CONTEXT(g_object_new(TYPE_INPUT_METHOD_CONTEXT, "observer", observer.get()));
 }
 
-void
-input_method_context_set_content(WebKitInputMethodContext *context, const char c)
+void input_method_context_set_content(WebKitInputMethodContext* context, const char c)
 {
     g_signal_emit_by_name(context, "committed", &c);
 }
 
-void
-input_method_context_delete_content(WebKitInputMethodContext *context, int offset)
+void input_method_context_delete_content(WebKitInputMethodContext* context, int offset)
 {
     g_signal_emit_by_name(context, "delete-surrounding", offset, 1);
 }

--- a/wpe/src/main/glue/browser/inputmethodcontext.h
+++ b/wpe/src/main/glue/browser/inputmethodcontext.h
@@ -1,22 +1,24 @@
-# pragma once
+#pragma once
+
+#include "pageeventobserver.h"
 
 #include <wpe/webkit.h>
 #include <memory>
-
-#include "pageeventobserver.h"
 
 G_BEGIN_DECLS
 
 #define TYPE_INPUT_METHOD_CONTEXT (input_method_context_get_type())
 
-G_DECLARE_DERIVABLE_TYPE(InputMethodContext, input_method_context, WPE_ANDROID, INPUT_METHOD_CONTEXT, WebKitInputMethodContext)
+G_DECLARE_DERIVABLE_TYPE(InputMethodContext, input_method_context, WPE_ANDROID, INPUT_METHOD_CONTEXT,
+                         WebKitInputMethodContext)
 
-struct _InputMethodContextClass {
+struct _InputMethodContextClass
+{
     WebKitInputMethodContextClass parent_class;
 };
 
-WebKitInputMethodContext *input_method_context_new(std::shared_ptr<PageEventObserver>);
-void input_method_context_set_content(WebKitInputMethodContext*, const char c);
-void input_method_context_delete_content(WebKitInputMethodContext*, int offset);
+WebKitInputMethodContext* input_method_context_new(std::shared_ptr<PageEventObserver> observer);
+void input_method_context_set_content(WebKitInputMethodContext* context, const char c);
+void input_method_context_delete_content(WebKitInputMethodContext* context, int offset);
 
 G_END_DECLS

--- a/wpe/src/main/glue/browser/looperthread.cpp
+++ b/wpe/src/main/glue/browser/looperthread.cpp
@@ -3,7 +3,7 @@
 #include "logging.h"
 #include <android/looper.h>
 
-static LooperThread* s_looperThread;
+static LooperThread* s_looperThread = nullptr;
 
 LooperThread::~LooperThread()
 {

--- a/wpe/src/main/glue/browser/looperthread.h
+++ b/wpe/src/main/glue/browser/looperthread.h
@@ -2,15 +2,17 @@
 
 struct ALooper;
 
-class LooperThread {
+class LooperThread final
+{
 public:
     static void initialize();
     static LooperThread& instance();
 
     ~LooperThread();
 
-    ALooper* looper() const { return m_looper; }
+    ALooper* looper() const
+    { return m_looper; }
 
 private:
-    ALooper* m_looper { nullptr };
+    ALooper* m_looper = nullptr;
 };

--- a/wpe/src/main/glue/browser/page.cpp
+++ b/wpe/src/main/glue/browser/page.cpp
@@ -1,20 +1,63 @@
-#include <algorithm>
 #include "page.h"
 
 #include "browser.h"
 #include "logging.h"
 #include "renderer_asurfacetransaction.h"
 #include "renderer_fallback.h"
+
+#include <algorithm>
 #include <android/api-level.h>
 #include <android/hardware_buffer.h>
 
-static void onLoadChanged(WebKitWebView *, WebKitLoadEvent, gpointer);
+namespace {
+void onLoadChanged(WebKitWebView*, WebKitLoadEvent loadEvent, gpointer data)
+{
+    auto* observer = reinterpret_cast<PageEventObserver*>(data);
+    if (observer != nullptr) {
+        observer->onLoadChanged(loadEvent);
+    }
+}
 
-static void onLoadProgressChanged(WebKitWebView *, GParamSpec *, gpointer);
+void onLoadProgressChanged(WebKitWebView* webView, GParamSpec*, gpointer data)
+{
+    auto* observer = reinterpret_cast<PageEventObserver*>(data);
+    if (observer != nullptr) {
+        gdouble progress = webkit_web_view_get_estimated_load_progress(webView);
+        observer->onLoadProgress(progress);
+    }
+}
 
-static void onUriChanged(WebKitWebView *, GParamSpec *, gpointer);
+void onUriChanged(WebKitWebView* webView, GParamSpec*, gpointer data)
+{
+    auto* observer = reinterpret_cast<PageEventObserver*>(data);
+    if (observer != nullptr) {
+        const char* uri = webkit_web_view_get_uri(webView);
+        observer->onUriChanged(uri);
+    }
+}
 
-static void onTitleChanged(WebKitWebView *, GParamSpec *, gpointer);
+void onTitleChanged(WebKitWebView* webView, GParamSpec*, gpointer data)
+{
+    auto* observer = reinterpret_cast<PageEventObserver*>(data);
+    if (observer != nullptr) {
+        const char* title = webkit_web_view_get_title(webView);
+        gboolean canGoBack = webkit_web_view_can_go_back(webView);
+        gboolean canGoForward = webkit_web_view_can_go_forward(webView);
+        observer->onTitleChanged(title, canGoBack, canGoForward);
+    }
+}
+} // namespace
+
+struct wpe_android_view_backend_exportable_client Page::s_exportableClient = {
+        // export_buffer
+        [](void* data, AHardwareBuffer* buffer, uint32_t poolID, uint32_t bufferID) {
+            ALOGV("s_exportableClient::export_buffer() buffer %p poolID %u bufferID %u", buffer, poolID, bufferID);
+            auto* page = reinterpret_cast<Page*>(data);
+
+            Browser::getInstance().handleExportedBuffer(*page,
+                                                        std::make_shared<ExportedBuffer>(buffer, poolID, bufferID));
+        }
+};
 
 Page::Page(int width, int height, const std::string& userAgent, std::shared_ptr<PageEventObserver> observer)
         : m_width(width),
@@ -23,7 +66,8 @@ Page::Page(int width, int height, const std::string& userAgent, std::shared_ptr<
           m_observer(observer),
           m_webView(nullptr),
           m_viewBackendExportable(nullptr),
-          m_initialized(false) {
+          m_initialized(false)
+{
     m_signalHandlers.clear();
 
 #if __ANDROID_API__ >= 29
@@ -31,7 +75,7 @@ Page::Page(int width, int height, const std::string& userAgent, std::shared_ptr<
         m_renderer = std::make_unique<RendererASurfaceTransaction>(*this, m_width, m_height);
     else
 #endif
-        m_renderer = std::make_unique<RendererFallback>(*this, m_width, m_height);
+    m_renderer = std::make_unique<RendererFallback>(*this, m_width, m_height);
 }
 
 void Page::init()
@@ -41,7 +85,7 @@ void Page::init()
     }
 
     ALOGV("Initializing Page");
-    struct wpe_view_backend *wpeBackend;
+    struct wpe_view_backend* wpeBackend;
     {
         m_viewBackendExportable = wpe_android_view_backend_exportable_create(&s_exportableClient, this,
                                                                              std::max(0, m_width),
@@ -49,7 +93,7 @@ void Page::init()
         wpeBackend = wpe_android_view_backend_exportable_get_view_backend(m_viewBackendExportable);
     }
 
-    auto *viewBackend = webkit_web_view_backend_new(wpeBackend, NULL, NULL);
+    auto* viewBackend = webkit_web_view_backend_new(wpeBackend, nullptr, nullptr);
 
     m_webView = webkit_web_view_new(viewBackend);
 
@@ -70,7 +114,7 @@ void Page::init()
 
     webkit_web_view_set_input_method_context(m_webView, m_input_method_context);
 
-    auto *settings = webkit_web_view_get_settings(m_webView);
+    auto* settings = webkit_web_view_get_settings(m_webView);
     webkit_settings_set_user_agent(settings, m_userAgent.c_str());
     webkit_web_view_set_settings(m_webView, settings);
 
@@ -86,14 +130,14 @@ void Page::close()
         return;
     }
     m_initialized = false;
-    for (auto &handler : m_signalHandlers) {
+    for (auto& handler: m_signalHandlers) {
         g_signal_handler_disconnect(m_webView, handler);
     }
     m_signalHandlers.clear();
     webkit_web_view_try_close(m_webView);
 }
 
-void Page::loadUrl(const char *url)
+void Page::loadUrl(const char* url)
 {
     ALOGV("Page::loadUrl %s %p", url, m_webView);
     webkit_web_view_load_uri(m_webView, url);
@@ -127,13 +171,13 @@ void Page::surfaceCreated(ANativeWindow* window)
 
 void Page::surfaceChanged(int format, int width, int height)
 {
-    uint32_t uwidth = uint32_t(std::max(0, width));
-    uint32_t uheight = uint32_t(std::max(0, height));
-    ALOGV("Page::surfaceChanged() format %d size (%u,%u)", format, uwidth, uheight);
-    struct wpe_view_backend *viewBackend = wpe_android_view_backend_exportable_get_view_backend(
+    uint32_t uWidth = uint32_t(std::max(0, width));
+    uint32_t uHeight = uint32_t(std::max(0, height));
+    ALOGV("Page::surfaceChanged() format %d size (%u,%u)", format, uWidth, uHeight);
+    struct wpe_view_backend* viewBackend = wpe_android_view_backend_exportable_get_view_backend(
             m_viewBackendExportable);
-    wpe_view_backend_dispatch_set_size(viewBackend, uwidth, uheight);
-    m_renderer->surfaceChanged(format, uwidth, uheight);
+    wpe_view_backend_dispatch_set_size(viewBackend, uWidth, uHeight);
+    m_renderer->surfaceChanged(format, uWidth, uHeight);
 }
 
 void Page::surfaceRedrawNeeded()
@@ -152,7 +196,7 @@ void Page::handleExportedBuffer(const std::shared_ptr<ExportedBuffer>& exportedB
     m_renderer->handleExportedBuffer(exportedBuffer);
 }
 
-void Page::onTouch(wpe_input_touch_event_raw *touchEventRaw)
+void Page::onTouch(wpe_input_touch_event_raw* touchEventRaw)
 {
     struct wpe_input_touch_event touchEvent {};
     touchEvent.touchpoints = touchEventRaw;
@@ -161,7 +205,7 @@ void Page::onTouch(wpe_input_touch_event_raw *touchEventRaw)
     touchEvent.id = 0;
     touchEvent.time = touchEventRaw->time;
 
-    struct wpe_view_backend *viewBackend = wpe_android_view_backend_exportable_get_view_backend(
+    struct wpe_view_backend* viewBackend = wpe_android_view_backend_exportable_get_view_backend(
             m_viewBackendExportable);
     wpe_view_backend_dispatch_touch_event(viewBackend, &touchEvent);
 }
@@ -179,52 +223,4 @@ void Page::setInputMethodContent(const char c)
 void Page::deleteInputMethodContent(int offset)
 {
     input_method_context_delete_content(m_input_method_context, offset);
-}
-
-struct wpe_android_view_backend_exportable_client Page::s_exportableClient = {
-    // export_buffer
-    [](void* data, AHardwareBuffer* buffer, uint32_t poolID, uint32_t bufferID)
-    {
-        ALOGV("s_exportableClient::export_buffer() buffer %p poolID %u bufferID %u", buffer, poolID, bufferID);
-        auto *page = reinterpret_cast<Page *>(data);
-
-        Browser::getInstance().handleExportedBuffer(*page, std::make_shared<ExportedBuffer>(buffer, poolID, bufferID));
-    },
-};
-
-static void onLoadChanged(WebKitWebView *, WebKitLoadEvent loadEvent, gpointer data)
-{
-    auto *observer = reinterpret_cast<PageEventObserver *>(data);
-    if (observer != nullptr) {
-        observer->onLoadChanged(loadEvent);
-    }
-}
-
-static void onLoadProgressChanged(WebKitWebView *webView, GParamSpec *, gpointer data)
-{
-    auto *observer = reinterpret_cast<PageEventObserver *>(data);
-    if (observer != nullptr) {
-        gdouble progress = webkit_web_view_get_estimated_load_progress(webView);
-        observer->onLoadProgress(progress);
-    }
-}
-
-static void onUriChanged(WebKitWebView *webView, GParamSpec *, gpointer data)
-{
-    auto *observer = reinterpret_cast<PageEventObserver *>(data);
-    if (observer != nullptr) {
-        const char *uri = webkit_web_view_get_uri(webView);
-        observer->onUriChanged(uri);
-    }
-}
-
-static void onTitleChanged(WebKitWebView *webView, GParamSpec *, gpointer data)
-{
-    auto *observer = reinterpret_cast<PageEventObserver *>(data);
-    if (observer != nullptr) {
-        const char *title = webkit_web_view_get_title(webView);
-        gboolean canGoBack = webkit_web_view_can_go_back(webView);
-        gboolean canGoForward = webkit_web_view_can_go_forward(webView);
-        observer->onTitleChanged(title, canGoBack, canGoForward);
-    }
 }

--- a/wpe/src/main/glue/browser/page.h
+++ b/wpe/src/main/glue/browser/page.h
@@ -1,26 +1,25 @@
 #pragma once
 
+#include "inputmethodcontext.h"
+#include "pageeventobserver.h"
+#include "renderer.h"
+
 #include <wpe/webkit.h>
 #include <wpe/wpe.h>
 #include <memory>
 #include <string>
 #include <vector>
 
-#include "inputmethodcontext.h"
-#include "pageeventobserver.h"
-#include "renderer.h"
-
 #include <wpe-android/view-backend-exportable.h>
 
-typedef struct AHardwareBuffer AHardwareBuffer;
 struct ANativeWindow;
-struct ASurfaceControl;
-
 struct ExportedBuffer;
 
-class Page {
+class Page
+{
 public:
-    Page(int width, int height, const std::string& userAgent, std::shared_ptr<PageEventObserver>);
+    Page(int width, int height, const std::string& userAgent, std::shared_ptr<PageEventObserver> observer);
+
     Page(Page&&) = delete;
     Page& operator=(Page&&) = delete;
     Page(const Page&) = delete;
@@ -35,19 +34,20 @@ public:
     void stopLoading();
     void reload();
 
-    void surfaceCreated(ANativeWindow*);
+    void surfaceCreated(ANativeWindow* window);
     void surfaceChanged(int format, int width, int height);
     void surfaceRedrawNeeded();
     void surfaceDestroyed();
-    void handleExportedBuffer(const std::shared_ptr<ExportedBuffer>&);
+    void handleExportedBuffer(const std::shared_ptr<ExportedBuffer>& exportedBuffer);
 
-    void onTouch(wpe_input_touch_event_raw*);
+    void onTouch(wpe_input_touch_event_raw* touchEventRaw);
     void setZoomLevel(double zoomLevel);
 
     void setInputMethodContent(const char c);
     void deleteInputMethodContent(int offset);
 
-    struct wpe_android_view_backend_exportable* exportable() { return m_viewBackendExportable; }
+    struct wpe_android_view_backend_exportable* exportable()
+    { return m_viewBackendExportable; }
 
 private:
     static struct wpe_android_view_backend_exportable_client s_exportableClient;
@@ -56,11 +56,10 @@ private:
     int m_height = 0;
     std::string m_userAgent;
     bool m_initialized = false;
-    WebKitWebView* m_webView;
-    struct wpe_android_view_backend_exportable* m_viewBackendExportable;
+    WebKitWebView* m_webView = nullptr;
+    struct wpe_android_view_backend_exportable* m_viewBackendExportable = nullptr;
     std::unique_ptr<Renderer> m_renderer;
     std::shared_ptr<PageEventObserver> m_observer;
     std::vector<gulong> m_signalHandlers;
-    WebKitInputMethodContext* m_input_method_context;
-
+    WebKitInputMethodContext* m_input_method_context = nullptr;
 };

--- a/wpe/src/main/glue/browser/pageeventobserver.h
+++ b/wpe/src/main/glue/browser/pageeventobserver.h
@@ -3,26 +3,32 @@
 #include <jni.h>
 #include <wpe-webkit/wpe/webkit.h>
 
-typedef struct AHardwareBuffer AHardwareBuffer;
-
-class PageEventObserver {
-    JavaVM *vm;
-    jclass pageClass;
-    jobject pageObj;
-
+class PageEventObserver final
+{
 public:
-    PageEventObserver(JavaVM *vm, jclass klass, jobject obj) : vm(vm), pageClass(klass), pageObj(obj) {}
+    PageEventObserver(JNIEnv* env, jclass klass, jobject obj);
+    ~PageEventObserver();
+
     PageEventObserver(PageEventObserver&&) = delete;
     PageEventObserver& operator=(PageEventObserver&&) = delete;
     PageEventObserver(const PageEventObserver&) = delete;
     PageEventObserver& operator=(const PageEventObserver&) = delete;
-    ~PageEventObserver();
 
-    void onLoadChanged(WebKitLoadEvent);
-    void onLoadProgress(double);
-    void onUriChanged(const char*);
-    void onTitleChanged(const char*, gboolean canGoBack, gboolean canGoForward);
+    static constexpr int NB_JAVA_METHODS = 6;
+
+    void onLoadChanged(WebKitLoadEvent loadEvent);
+    void onLoadProgress(double progress);
+    void onUriChanged(const char* uri);
+    void onTitleChanged(const char* title, gboolean canGoBack, gboolean canGoForward);
 
     void onInputMethodContextIn();
     void onInputMethodContextOut();
+
+private:
+    template<typename... Args>
+    void callJavaVoidMethod(int methodIdx, Args&& ... args);
+
+    jclass m_pageClass = nullptr;
+    jobject m_pageObj = nullptr;
+    jmethodID m_javaMethodIDs[NB_JAVA_METHODS] = { 0 };
 };

--- a/wpe/src/main/glue/browser/renderer.h
+++ b/wpe/src/main/glue/browser/renderer.h
@@ -4,7 +4,8 @@
 
 struct ANativeWindow;
 
-class Renderer {
+class Renderer
+{
 public:
     virtual ~Renderer() = default;
 

--- a/wpe/src/main/glue/browser/renderer_asurfacetransaction.cpp
+++ b/wpe/src/main/glue/browser/renderer_asurfacetransaction.cpp
@@ -2,14 +2,15 @@
 
 #if __ANDROID_API__ >= 29
 
-#include "exportedbuffer.h"
 #include "logging.h"
 #include "browser.h"
+
 #include <android/hardware_buffer.h>
 #include <android/surface_control.h>
 #include <wpe-android/view-backend-exportable.h>
 
-struct RendererASurfaceTransaction::TransactionContext {
+struct RendererASurfaceTransaction::TransactionContext
+{
     RendererASurfaceTransaction& renderer;
     std::shared_ptr<ExportedBuffer> buffer;
 };
@@ -17,12 +18,11 @@ struct RendererASurfaceTransaction::TransactionContext {
 static void releaseBuffer(struct wpe_android_view_backend_exportable* exportable, const ExportedBuffer& buffer)
 {
     wpe_android_view_backend_exportable_dispatch_release_buffer(exportable,
-            buffer.buffer, buffer.poolID, buffer.bufferID);
+                                                                buffer.buffer, buffer.poolID, buffer.bufferID);
 }
 
 RendererASurfaceTransaction::RendererASurfaceTransaction(Page& page, unsigned width, unsigned height)
-    : m_page(page)
-    , m_size({ width, height })
+        : m_page(page), m_size({ width, height })
 {
     ALOGV("RendererASurfaceTransaction() page %p", &m_page);
 }
@@ -41,7 +41,7 @@ RendererASurfaceTransaction::~RendererASurfaceTransaction()
     // If locked buffer still exists, release it.
     if (m_state.lockedBuffer)
         releaseBuffer(m_page.exportable(), *m_state.lockedBuffer);
-    m_state = { };
+    m_state = {};
 }
 
 void RendererASurfaceTransaction::surfaceCreated(ANativeWindow* window)

--- a/wpe/src/main/glue/browser/renderer_asurfacetransaction.h
+++ b/wpe/src/main/glue/browser/renderer_asurfacetransaction.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "renderer.h"
+
 #include <android/api-level.h>
 
 #if __ANDROID_API__ >= 29
@@ -11,7 +12,8 @@ struct ASurfaceTransactionStats;
 
 class Page;
 
-class RendererASurfaceTransaction final : public Renderer {
+class RendererASurfaceTransaction final : public Renderer
+{
 public:
     RendererASurfaceTransaction(Page&, unsigned width, unsigned height);
     virtual ~RendererASurfaceTransaction();
@@ -31,17 +33,20 @@ private:
     static void onTransactionComplete(void* data, ASurfaceTransactionStats* stats);
 
     Page& m_page;
-    struct {
+    struct
+    {
         ANativeWindow* window { nullptr };
         ASurfaceControl* control { nullptr };
     } m_surface;
 
-    struct {
+    struct
+    {
         unsigned width;
         unsigned height;
     } m_size;
 
-    struct {
+    struct
+    {
         bool dispatchFrameCompleteCallback { false };
 
         std::shared_ptr<ExportedBuffer> exportedBuffer;

--- a/wpe/src/main/glue/browser/renderer_fallback.cpp
+++ b/wpe/src/main/glue/browser/renderer_fallback.cpp
@@ -3,26 +3,27 @@
 #include "logging.h"
 #include "looperthread.h"
 #include "browser.h"
+
 #include <EGL/egl.h>
 #include <GLES2/gl2.h>
 #include <android/choreographer.h>
 #include <android/hardware_buffer.h>
 #include <android/native_window.h>
 #include <android/looper.h>
-#include <stdint.h>
+#include <cstdint>
 #include <sys/eventfd.h>
 #include <vector>
 #include <wpe-android/view-backend-exportable.h>
 
-struct RendererFallback::FrameContext {
+struct RendererFallback::FrameContext
+{
     RendererFallback& renderer;
     std::shared_ptr<ExportedBuffer> buffer;
     bool dispatchFrameCompleteCallback;
 };
 
 RendererFallback::RendererFallback(Page& page, unsigned width, unsigned height)
-    : m_page(page)
-    , m_size({ width, height })
+        : m_page(page), m_size({ width, height })
 {
     m_egl.display = eglGetDisplay(EGL_DEFAULT_DISPLAY);
     eglInitialize(m_egl.display, nullptr, nullptr);
@@ -166,7 +167,7 @@ void RendererFallback::surfaceDestroyed()
     eglMakeCurrent(m_egl.display, m_egl.surface, m_egl.surface, m_egl.context);
 
     if (m_egl.context != EGL_NO_CONTEXT) {
-        if (eglDestroyContext(m_egl.display,  m_egl.context) == EGL_FALSE) {
+        if (eglDestroyContext(m_egl.display, m_egl.context) == EGL_FALSE) {
             ALOGE("eglDestroyContext() failed: %d", eglGetError());
         }
         m_egl.context = EGL_NO_CONTEXT;
@@ -204,9 +205,9 @@ void RendererFallback::renderFrame(const std::shared_ptr<ExportedBuffer>& buffer
     {
         if (m_lockedBuffer) {
             wpe_android_view_backend_exportable_dispatch_release_buffer(m_page.exportable(),
-                    m_lockedBuffer->buffer,
-                    m_lockedBuffer->poolID,
-                    m_lockedBuffer->bufferID);
+                                                                        m_lockedBuffer->buffer,
+                                                                        m_lockedBuffer->poolID,
+                                                                        m_lockedBuffer->bufferID);
 
             m_lockedBuffer = nullptr;
         }
@@ -226,7 +227,7 @@ void RendererFallback::renderFrame(const std::shared_ptr<ExportedBuffer>& buffer
         EGLImageKHR image = m_egl.createImageKHR(m_egl.display, EGL_NO_CONTEXT,
                                                  EGL_NATIVE_BUFFER_ANDROID, clientBuffer, nullptr);
         ALOGV("RendererFallback: clientBuffer %p => image %p, err %x, size (%u,%u)",
-                clientBuffer, image, eglGetError(), m_size.width, m_size.height);
+              clientBuffer, image, eglGetError(), m_size.width, m_size.height);
 
         glUseProgram(m_gl.program);
 
@@ -236,10 +237,10 @@ void RendererFallback::renderFrame(const std::shared_ptr<ExportedBuffer>& buffer
         glUniform1i(m_gl.uniform_texture, 0);
 
         static float positionCoords[] = {
-                -1,1,  1,1,  -1,-1,  1,-1,
+                -1, 1, 1, 1, -1, -1, 1, -1,
         };
         static float textureCoords[] = {
-                0,0,  1,0,  0,1,  1,1,
+                0, 0, 1, 0, 0, 1, 1, 1,
         };
 
         glVertexAttribPointer(m_gl.attr_pos, 2, GL_FLOAT, GL_FALSE, 0, positionCoords);

--- a/wpe/src/main/glue/browser/renderer_fallback.h
+++ b/wpe/src/main/glue/browser/renderer_fallback.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "renderer.h"
+
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
 #include <GLES2/gl2.h>
@@ -8,7 +9,8 @@
 
 class Page;
 
-class RendererFallback final : public Renderer {
+class RendererFallback final : public Renderer
+{
 public:
     RendererFallback(Page&, unsigned width, unsigned height);
     virtual ~RendererFallback();
@@ -22,6 +24,7 @@ public:
 
 private:
     struct FrameContext;
+
     void scheduleFrame(FrameContext*);
     void renderFrame(const std::shared_ptr<ExportedBuffer>&, bool dispatchFrameCompleteCallback);
 
@@ -30,12 +33,14 @@ private:
 
     Page& m_page;
 
-    struct {
+    struct
+    {
         unsigned width { 0 };
         unsigned height { 0 };
     } m_size;
 
-    struct {
+    struct
+    {
         EGLDisplay display { EGL_NO_DISPLAY };
 
         EGLConfig config { 0 };
@@ -48,7 +53,8 @@ private:
         PFNGLEGLIMAGETARGETTEXTURE2DOESPROC imageTargetTexture2DOES;
     } m_egl;
 
-    struct {
+    struct
+    {
         GLint vertexShader { 0 };
         GLint fragmentShader { 0 };
         GLint program { 0 };
@@ -59,7 +65,8 @@ private:
         GLint uniform_texture;
     } m_gl;
 
-    struct {
+    struct
+    {
         int fd { -1 };
     } m_update;
 

--- a/wpe/src/main/glue/common/jnihelper.cpp
+++ b/wpe/src/main/glue/common/jnihelper.cpp
@@ -1,41 +1,67 @@
 #include "jnihelper.h"
 
-#include <cstdlib>
-#include <sys/prctl.h>
-
 #include "logging.h"
 
-namespace wpe {
-namespace android {
+#include <pthread.h>
+#include <stdexcept>
+
 namespace {
+JavaVM* s_javaVM = nullptr;
+pthread_key_t s_currentJNIEnvKey = 0;
 
-JavaVM *g_jvm = NULL;
-
-}
-
-void InitVM(JavaVM *vm) {
-    g_jvm = vm;
-}
-
-JNIEnv *AttachCurrentThread() {
-    JNIEnv *env = nullptr;
-    jint ret = g_jvm->GetEnv(reinterpret_cast<void **>(&env), JNI_VERSION_1_6);
-    if (ret == JNI_EDETACHED || !env) {
-        JavaVMAttachArgs args = { JNI_VERSION_1_6, nullptr, nullptr };
-
-        char thread_name[16]; // 16 is the max size for android thread names
-        int err = prctl(PR_GET_NAME, thread_name);
-        if (err >= 0) {
-            args.name = thread_name;
-        }
-
-        if (g_jvm->AttachCurrentThread(&env, &args) != JNI_OK) {
-            ALOGE("Failed to attach thread");
-            std::abort();
-        }
+void detachTerminatedNativeThread(void*)
+{
+    if (s_javaVM != nullptr) {
+        ALOGV("Detaching terminated native thread %ld", pthread_self());
+        s_javaVM->DetachCurrentThread();
     }
+}
+}  // namespace
+
+JNIEnv* wpe::android::initVM(JavaVM* vm)
+{
+    if (s_javaVM != nullptr) {
+        ALOGE("Fatal error: Java VM already initialized for current process");
+        throw std::runtime_error("Java VM already initialized for current process");
+    }
+
+    JNIEnv* env = nullptr;
+    if (vm->GetEnv(reinterpret_cast<void**>(&env), wpe::android::JNI_VERSION) != JNI_OK) {
+        ALOGE("Fatal error: cannot fetch JNIEnv from JavaVM initialization");
+        throw std::runtime_error("Cannot fetch JNIEnv from JavaVM initialization");
+    }
+
+    if (pthread_key_create(&s_currentJNIEnvKey, detachTerminatedNativeThread) != 0) {
+        ALOGE("Fatal error: cannot create pthread key for native threads");
+        throw std::runtime_error("Cannot create pthread key for native threads");
+    }
+
+    s_javaVM = vm;
     return env;
 }
 
-} // namespace android
-} // namespace wpe
+JNIEnv* wpe::android::getCurrentThreadJNIEnv()
+{
+    JNIEnv* env = reinterpret_cast<JNIEnv*>(pthread_getspecific(s_currentJNIEnvKey));
+    if (env == nullptr && s_javaVM != nullptr) {
+        if (s_javaVM->GetEnv(reinterpret_cast<void**>(&env), wpe::android::JNI_VERSION) == JNI_EDETACHED) {
+            JavaVMAttachArgs args = { 0 };
+            args.version = wpe::android::JNI_VERSION;
+
+            char threadName[16]; // 16 is the max size for android thread names (including terminating char)
+            if (pthread_getname_np(pthread_self(), threadName, sizeof(threadName)) == 0)
+                args.name = threadName;
+
+            ALOGV("Attaching native thread %ld", pthread_self());
+            if (s_javaVM->AttachCurrentThread(&env, &args) == JNI_OK)
+                pthread_setspecific(s_currentJNIEnvKey, env);
+        }
+    }
+
+    if (env == nullptr) {
+        ALOGE("Fatal error: cannot fetch current thread JNIEnv");
+        throw std::runtime_error("Cannot fetch current thread JNIEnv");
+    }
+
+    return env;
+}

--- a/wpe/src/main/glue/common/jnihelper.h
+++ b/wpe/src/main/glue/common/jnihelper.h
@@ -2,54 +2,11 @@
 
 #include <jni.h>
 
-namespace wpe {
-namespace android {
+namespace wpe { namespace android {
 
-void InitVM(JavaVM* vm);
+constexpr jint JNI_VERSION = JNI_VERSION_1_6;
 
-JNIEnv* AttachCurrentThread();
+JNIEnv* initVM(JavaVM* vm);
+JNIEnv* getCurrentThreadJNIEnv();
 
-} // namespace android
-} // namespace wpe
-
-static bool getJniEnv(JavaVM *vm, JNIEnv **env) {
-    bool didAttachThread = false;
-    *env = nullptr;
-    auto get_env_result = vm->GetEnv((void**)env, JNI_VERSION_1_6);
-    if (get_env_result == JNI_EDETACHED) {
-        if (vm->AttachCurrentThread(env, NULL) == JNI_OK) {
-            didAttachThread = true;
-        } else {
-            throw;
-        }
-    } else if (get_env_result == JNI_EVERSION) {
-        // Unsupported JNI version.
-        throw;
-    }
-    return didAttachThread;
-}
-
-class ScopedEnv {
-public:
-    ScopedEnv(JavaVM *vm) : vm(vm), attachedToVm(false) {
-        attachedToVm = getJniEnv(vm, &env);
-    }
-
-    ScopedEnv(const ScopedEnv&) = delete;
-    ScopedEnv& operator=(const ScopedEnv&) = delete;
-
-    virtual ~ScopedEnv() {
-        if (attachedToVm) {
-            vm->DetachCurrentThread();
-            attachedToVm = false;
-        }
-    }
-
-    JNIEnv *getEnv() const { return env; }
-
-private:
-    bool attachedToVm;
-    JavaVM *vm;
-    JNIEnv *env;
-};
-
+}} // namespace wpe::android

--- a/wpe/src/main/glue/common/logging.cpp
+++ b/wpe/src/main/glue/common/logging.cpp
@@ -1,0 +1,44 @@
+#include "logging.h"
+
+#include <pthread.h>
+#include <cstdio>
+#include <unistd.h>
+#include <cstdlib>
+
+bool wpe::android::pipeStdoutToLogcat()
+{
+    // Make stdout line-buffered and stderr unbuffered
+    setvbuf(stdout, nullptr, _IOLBF, 0);
+    setvbuf(stderr, nullptr, _IONBF, 0);
+
+    // Create the pipe and redirect stdout and stderr
+    int pfd[2] = { 0 };
+    pipe(pfd);
+    dup2(pfd[1], 1);
+    dup2(pfd[1], 2);
+
+    // Spawn the logging thread
+    pthread_t logging_thread = 0;
+    if (pthread_create(&logging_thread, nullptr, +[](void* userData) -> void* {
+        ssize_t rdsz = 0;
+        char buf[128] = { 0 };
+        while ((rdsz = read(reinterpret_cast<int*>(userData)[0], buf, sizeof(buf) - 1)) > 0) {
+            if (buf[rdsz - 1] == '\n')
+                --rdsz;
+
+            buf[rdsz] = '\0';
+            __android_log_write(ANDROID_LOG_DEBUG, "wpe-android", buf);
+        }
+
+        return nullptr;
+    }, reinterpret_cast<void*>(pfd)) != 0)
+        return false;
+
+    pthread_detach(logging_thread);
+    return true;
+}
+
+void wpe::android::enableGstDebug()
+{
+    setenv("GST_DEBUG", "3", 1);
+}

--- a/wpe/src/main/glue/common/logging.h
+++ b/wpe/src/main/glue/common/logging.h
@@ -1,50 +1,13 @@
 #pragma once
 
 #include <android/log.h>
-#include <pthread.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <unistd.h>
 
 #define ALOGE(...) __android_log_print(ANDROID_LOG_ERROR, "WPE Glue", __VA_ARGS__)
 #define ALOGV(...) __android_log_print(ANDROID_LOG_VERBOSE, "WPE Glue", __VA_ARGS__)
 
-static int pfd[2];
-static pthread_t thr;
-static const char *tag = "wpe-android";
+namespace wpe { namespace android {
 
-static void *thread_func(void*)
-{
-    ssize_t rdsz;
-    char buf[128];
-    while((rdsz = read(pfd[0], buf, sizeof buf - 1)) > 0) {
-        if(buf[rdsz - 1] == '\n') --rdsz;
-        buf[rdsz] = 0;
-        __android_log_write(ANDROID_LOG_DEBUG, tag, buf);
-    }
-    return 0;
-}
+bool pipeStdoutToLogcat();
+void enableGstDebug();
 
-static int pipe_stdout_to_logcat()
-{
-    // Make stdout line-buffered and stderr unbuffered
-    setvbuf(stdout, 0, _IOLBF, 0);
-    setvbuf(stderr, 0, _IONBF, 0);
-
-    // Create the pipe and redirect stdout and stderr
-    pipe(pfd);
-    dup2(pfd[1], 1);
-    dup2(pfd[1], 2);
-
-    // Spawn the logging thread
-    if(pthread_create(&thr, 0, thread_func, 0) == -1)
-        return -1;
-    pthread_detach(thr);
-    return 0;
-}
-
-static void enable_gst_debug()
-{
-    setenv("GST_DEBUG", "3", 1);
-}
-
+}} // namespace wpe::android

--- a/wpe/src/main/glue/webprocess/entrypoints.cpp
+++ b/wpe/src/main/glue/webprocess/entrypoints.cpp
@@ -1,27 +1,21 @@
-#include <jni.h>
-#include <android/native_window_jni.h>
-#include <dlfcn.h>
-#include <gio/gio.h>
-#include <glib/gtypes.h>
-#include <stdio.h>
-#include <stdlib.h>
-
 #include "logging.h"
+#include "jnihelper.h"
+
+#include <dlfcn.h>
+#include <glib.h>
+#include <unistd.h>
 
 extern "C" {
-JNIEXPORT void JNICALL Java_com_wpe_wpe_services_WebProcessGlue_initializeMain(JNIEnv*, jobject, jint, jint);
-JNIEXPORT void JNICALL Java_com_wpe_wpe_services_WebProcessGlue_setupEnvironment(JNIEnv*, jobject, jstring, jstring, jstring, jstring, jstring, jstring);
-jint JNI_OnLoad(JavaVM*, void *);
+JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM*, void*);
 }
 
-using WebProcessEntryPoint = int(int, char**);
-
-JNIEXPORT void JNICALL
-Java_com_wpe_wpe_services_WebProcessGlue_initializeMain(JNIEnv*, jobject, jint fd1, jint fd2)
+namespace {
+void initializeMain(JNIEnv*, jclass, jint fd1, jint fd2)
 {
-    pipe_stdout_to_logcat();
-    enable_gst_debug();
+    wpe::android::pipeStdoutToLogcat();
+    wpe::android::enableGstDebug();
 
+    using WebProcessEntryPoint = int(int, char**);
     auto* entrypoint = reinterpret_cast<WebProcessEntryPoint*>(dlsym(RTLD_DEFAULT, "android_WebProcess_main"));
     ALOGV("Glue::initializeMain(), fd1 %d, fd2 %d, entrypoint %p", fd1, fd2, entrypoint);
 
@@ -33,68 +27,81 @@ Java_com_wpe_wpe_services_WebProcessGlue_initializeMain(JNIEnv*, jobject, jint f
     snprintf(fd2String, sizeof(fd1String), "%d", fd2);
 
     char* argv[4];
-    argv[0] = (char*)"WPEWebProcess";
+    argv[0] = const_cast<char*>("WPEWebProcess");
     argv[1] = pidString;
     argv[2] = fd1String;
     argv[3] = fd2String;
     (*entrypoint)(4, argv);
 }
 
-void Java_com_wpe_wpe_services_WebProcessGlue_setupEnvironment(JNIEnv *env, jobject,
-                                   jstring fontconfigPath,
-                                   jstring gstreamerPath,
-                                   jstring gioPath,
-                                   jstring nativeLibsPath,
-                                   jstring cachePath,
-                                   jstring filesPath) {
+void setupEnvironment(JNIEnv* env, jclass, jstring fontconfigPath, jstring gstreamerPath, jstring gioPath,
+                      jstring nativeLibsPath, jstring cachePath, jstring filesPath)
+{
     ALOGV("Glue::setupEnvironment()");
 
-    const char* _fontconfigPath = env->GetStringUTFChars(fontconfigPath, 0);
-    const char* _gstreamerPath = env->GetStringUTFChars(gstreamerPath, 0);
-    const char* _gioPath = env->GetStringUTFChars(gioPath, 0);
-    const char* _cachePath = env->GetStringUTFChars(cachePath, 0);
-    const char* _nativeLibsPath = env->GetStringUTFChars(nativeLibsPath, 0);
-    const char* _filesPath = env->GetStringUTFChars(filesPath, 0);
+    const char* str = env->GetStringUTFChars(fontconfigPath, nullptr);
+    setenv("FONTCONFIG_PATH", str, 1);
+    env->ReleaseStringUTFChars(fontconfigPath, str);
 
-    setenv("FONTCONFIG_PATH", _fontconfigPath, 1);
+    str = env->GetStringUTFChars(gstreamerPath, nullptr);
+    setenv("GST_PLUGIN_PATH", str, 1);
+    setenv("GST_PLUGIN_SYSTEM_PATH", str, 1);
+    env->ReleaseStringUTFChars(gstreamerPath, str);
 
-    setenv("GST_PLUGIN_PATH", _gstreamerPath, 1);
-    setenv("GST_PLUGIN_SYSTEM_PATH", _gstreamerPath, 1);
-    setenv("LD_LIBRARY_PATH", _nativeLibsPath, 1);
-    setenv("LIBRARY_PATH", _nativeLibsPath, 1);
-    setenv("TMP", _cachePath, 1);
-    setenv("TEMP", _cachePath, 1);
-    setenv("TMPDIR", _cachePath, 1);
-    gchar* registry = g_build_filename(_cachePath, "registry.bin", NULL);
+    str = env->GetStringUTFChars(gioPath, nullptr);
+    setenv("GIO_EXTRA_MODULES", str, 1);
+    env->ReleaseStringUTFChars(gioPath, str);
+
+    str = env->GetStringUTFChars(nativeLibsPath, nullptr);
+    setenv("LD_LIBRARY_PATH", str, 1);
+    setenv("LIBRARY_PATH", str, 1);
+    env->ReleaseStringUTFChars(nativeLibsPath, str);
+
+    str = env->GetStringUTFChars(cachePath, nullptr);
+    setenv("TMP", str, 1);
+    setenv("TEMP", str, 1);
+    setenv("TMPDIR", str, 1);
+    gchar* registry = g_build_filename(str, "registry.bin", nullptr);
     setenv("GST_REGISTRY", registry, 1);
     g_free(registry);
+    setenv("XDG_CACHE_HOME", str, 1);
+    setenv("XDG_RUNTIME_DIR", str, 1);
+    env->ReleaseStringUTFChars(cachePath, str);
+
     setenv("GST_REGISTRY_UPDATE", "no", 1);
-    setenv ("GST_REGISTRY_REUSE_PLUGIN_SCANNER", "no", 1);
+    setenv("GST_REGISTRY_REUSE_PLUGIN_SCANNER", "no", 1);
 
-    setenv("XDG_CACHE_HOME", _cachePath, 1);
-    setenv("XDG_RUNTIME_DIR", _cachePath, 1);
-    setenv("HOME", _filesPath, 1);
-    setenv("XDG_DATA_DIRS", _filesPath, 1);
-    setenv("XDG_CONFIG_DIRS", _filesPath, 1);
-    setenv("XDG_CONFIG_HOME", _filesPath, 1);
-    setenv("XDG_DATA_HOME", _filesPath, 1);
-
-    setenv("GIO_EXTRA_MODULES", _gioPath, 1);
+    str = env->GetStringUTFChars(filesPath, nullptr);
+    setenv("HOME", str, 1);
+    setenv("XDG_DATA_DIRS", str, 1);
+    setenv("XDG_CONFIG_DIRS", str, 1);
+    setenv("XDG_CONFIG_HOME", str, 1);
+    setenv("XDG_DATA_HOME", str, 1);
+    env->ReleaseStringUTFChars(filesPath, str);
 }
+} // namespace
 
-__attribute__((visibility("default")))
-jint JNI_OnLoad (JavaVM * vm, void *reserved)
+JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* reserved)
 {
-    // VM resolves and calls JNI_OnLoad from loaded library. libWPEWebKit has dependency
-    // to libgstreamer.so which also exports JNI_OnLoad. JNI_OnLoad in libgstreamer requires
-    // GStreamer java class to be present in specific package and call fails with invalid JNI
-    // version if GStreamer java class is not found. By declaring JNI_OnLoad here we prevent
-    // JNI_OnLoad in libgstreamer.so from being called as for now we don't need GStreamer Java bindings.
+    JNIEnv* env = wpe::android::initVM(vm);
+    jclass klass = env->FindClass("com/wpe/wpe/services/WebProcessGlue");
+    if (klass == nullptr)
+        return JNI_ERR;
 
+    static const JNINativeMethod methods[] = {
+            {
+                    "initializeMain",
+                    "(II)V",
+                    reinterpret_cast<void*>(initializeMain)
+            },
+            {
+                    "setupEnvironment",
+                    "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V",
+                    reinterpret_cast<void*>(setupEnvironment)
+            }
+    };
+    int result = env->RegisterNatives(klass, methods, sizeof(methods) / sizeof(JNINativeMethod));
+    env->DeleteLocalRef(klass);
 
-    // TODO: Instead of explicitly exporting native methods, register them using registerNativeMethods
-    //       which is recommended in https://developer.android.com/training/articles/perf-jni.html
-
-    return JNI_VERSION_1_6;
+    return (result != JNI_OK) ? result : wpe::android::JNI_VERSION;
 }
-

--- a/wpe/src/main/java/com/wpe/wpe/BrowserGlue.java
+++ b/wpe/src/main/java/com/wpe/wpe/BrowserGlue.java
@@ -8,7 +8,8 @@ import androidx.annotation.NonNull;
 import androidx.annotation.UiThread;
 
 @UiThread
-public class BrowserGlue {
+public class BrowserGlue
+{
     private static final String LOGTAG = "BrowserGlue";
 
     private final Browser m_browser;
@@ -22,7 +23,7 @@ public class BrowserGlue {
 
     public static native void init(BrowserGlue self);
     public static native void initLooperHelper();
-    public static native void deinit();
+    public static native void shut();
 
     public static native void newPage(Page page, int pageId, int width, int height, String userAgent);
     public static native void closePage(int pageId);
@@ -44,7 +45,8 @@ public class BrowserGlue {
     public static native void setInputMethodContent(int pageId, char c);
     public static native void deleteInputMethodContent(int m_id, int offset);
 
-    public BrowserGlue(@NonNull Browser browser) {
+    public BrowserGlue(@NonNull Browser browser)
+    {
         m_browser = browser;
     }
 
@@ -59,7 +61,8 @@ public class BrowserGlue {
      * @param fds File descriptors used by WebKit for IPC.
      */
     @Keep
-    public void launchProcess(long pid, int processType, @NonNull int[] fds) {
+    public void launchProcess(long pid, int processType, @NonNull int[] fds)
+    {
         Log.d(LOGTAG, "launchProcess " + pid);
         m_browser.launchAuxiliaryProcess(pid, processType, fds);
     }
@@ -71,13 +74,15 @@ public class BrowserGlue {
      *            the actual system pid.
      */
     @Keep
-    public void terminateProcess(long pid) {
+    public void terminateProcess(long pid)
+    {
         Log.d(LOGTAG, "terminateProcess " + pid);
         m_browser.terminateAuxiliaryProcess(pid);
     }
 
     @Keep
-    public void loadProgress(double progress) {
+    public void loadProgress(double progress)
+    {
         Log.d(LOGTAG, "progress " + progress);
     }
 }

--- a/wpe/src/main/java/com/wpe/wpe/Page.java
+++ b/wpe/src/main/java/com/wpe/wpe/Page.java
@@ -26,7 +26,8 @@ import java.util.regex.Pattern;
  * processes (WebProcess and NetworkProcess).
  */
 @UiThread
-public class Page {
+public class Page
+{
     private final String LOGTAG;
 
     static public final int LOAD_STARTED = 0;
@@ -59,7 +60,9 @@ public class Page {
     private static final int DefaultMinorVersion = 0;
     private static final int DefaultBugfixVersion = 0;
     private static String sOsVersion;
-    private String getOsVersion() {
+
+    private String getOsVersion()
+    {
         if (sOsVersion == null) {
             String releaseVersion = android.os.Build.VERSION.RELEASE;
             boolean validReleaseVersion = false;
@@ -71,21 +74,22 @@ public class Page {
                 if (majorVersionString != null && !majorVersionString.isEmpty()) {
                     validReleaseVersion = true;
                 }
-            } catch(Exception e) {}
+            } catch (Exception e) {}
 
             if (validReleaseVersion) {
                 sOsVersion = releaseVersion;
             } else {
                 sOsVersion = String.format("%d.%d.%d",
-                        DefaultMajorVersion,
-                        DefaultMinorVersion,
-                        DefaultBugfixVersion);
+                    DefaultMajorVersion,
+                    DefaultMinorVersion,
+                    DefaultBugfixVersion);
             }
         }
         return sOsVersion;
     }
 
-    public Page(@NonNull Browser browser, @NonNull Context context, @NonNull WPEView wpeView, int pageId) {
+    public Page(@NonNull Browser browser, @NonNull Context context, @NonNull WPEView wpeView, int pageId)
+    {
         LOGTAG = "WPE page" + pageId;
 
         Log.v(LOGTAG, "Page construction " + this);
@@ -96,7 +100,7 @@ public class Page {
         m_context = context;
         m_wpeView = wpeView;
 
-        m_width =  wpeView.getMeasuredWidth();
+        m_width = wpeView.getMeasuredWidth();
         m_height = wpeView.getMeasuredHeight();
 
         m_view = new View(m_context, pageId, wpeView);
@@ -106,7 +110,8 @@ public class Page {
         ensurePageGlue();
     }
 
-    public void close() {
+    public void close()
+    {
         if (m_closed) {
             return;
         }
@@ -122,7 +127,8 @@ public class Page {
      * This is called by the JNI layer. See `Java_com_wpe_wpe_BrowserGlue_newPage`
      */
     @Keep
-    public void onPageGlueReady() {
+    public void onPageGlueReady()
+    {
         Log.v(LOGTAG, "WebKitWebView ready " + m_pageGlueReady);
         m_pageGlueReady = true;
         if (m_viewReady) {
@@ -130,7 +136,8 @@ public class Page {
         }
     }
 
-    private void ensurePageGlue() {
+    private void ensurePageGlue()
+    {
         if (m_pageGlueReady) {
             onPageGlueReady();
             return;
@@ -145,7 +152,8 @@ public class Page {
         BrowserGlue.newPage(this, m_id, m_width, m_height, userAgentBuilder.toString());
     }
 
-    public void onViewReady() {
+    public void onViewReady()
+    {
         Log.d(LOGTAG, "onViewReady");
         m_wpeView.onViewReady(m_view);
         m_viewReady = true;
@@ -155,40 +163,44 @@ public class Page {
     }
 
     @WorkerThread
-    public WPEServiceConnection launchService(int processType, Parcelable[] fds, Class cls) {
+    public WPEServiceConnection launchService(int processType, Parcelable[] fds, Class cls)
+    {
         // This runs in the UIProcess thread.
         Log.v(LOGTAG, "launchService type: " + processType);
         Intent intent = new Intent(m_context, cls);
 
         WPEServiceConnection serviceConnection = new WPEServiceConnection(processType, this, fds);
         switch (processType) {
-            case WPEServiceConnection.PROCESS_TYPE_WEBPROCESS:
-                // FIXME: we probably want to kill the current web process here if any exists when
-                //        PSON is enabled.
-                m_browser.setWebProcess(serviceConnection);
-                break;
-            case WPEServiceConnection.PROCESS_TYPE_NETWORKPROCESS:
-                m_browser.setNetworkProcess(serviceConnection);
-                break;
-            default:
-                throw new IllegalArgumentException("Unknown process type");
+        case WPEServiceConnection.PROCESS_TYPE_WEBPROCESS:
+            // FIXME: we probably want to kill the current web process here if any exists when
+            //        PSON is enabled.
+            m_browser.setWebProcess(serviceConnection);
+            break;
+        case WPEServiceConnection.PROCESS_TYPE_NETWORKPROCESS:
+            m_browser.setNetworkProcess(serviceConnection);
+            break;
+        default:
+            throw new IllegalArgumentException("Unknown process type");
         }
         m_context.bindService(intent, serviceConnection, Context.BIND_AUTO_CREATE | Context.BIND_IMPORTANT);
         return serviceConnection;
     }
 
     @WorkerThread
-    public void stopService(WPEServiceConnection serviceConnection) {
+    public void stopService(WPEServiceConnection serviceConnection)
+    {
         Log.d(LOGTAG, "stopService type: " + serviceConnection.processType());
         // This runs in the UIProcess thread.
         // FIXME: Until we fully support PSON, we won't do anything here.
     }
 
-    public View view() {
+    public View view()
+    {
         return m_view;
     }
 
-    private void loadUrlInternal() {
+    private void loadUrlInternal()
+    {
         if (m_pendingLoad == null) {
             return;
         }
@@ -196,86 +208,102 @@ public class Page {
         m_pendingLoad = null;
     }
 
-    public void loadUrl(@NonNull Context context, @NonNull String url) {
+    public void loadUrl(@NonNull Context context, @NonNull String url)
+    {
         Log.d(LOGTAG, "Queue URL load " + url);
         m_pendingLoad = url;
         ensurePageGlue();
     }
 
-    public void onLoadChanged(int loadEvent) {
+    public void onLoadChanged(int loadEvent)
+    {
         m_wpeView.onLoadChanged(loadEvent);
         if (loadEvent == Page.LOAD_STARTED) {
             dismissKeyboard();
         }
     }
 
-    public void onLoadProgress(double progress) {
+    public void onLoadProgress(double progress)
+    {
         m_wpeView.onLoadProgress(progress);
     }
 
-    public void onUriChanged(String uri) {
+    public void onUriChanged(String uri)
+    {
         m_wpeView.onUriChanged(uri);
     }
 
-    public void onTitleChanged(String title, boolean canGoBack, boolean canGoForward) {
+    public void onTitleChanged(String title, boolean canGoBack, boolean canGoForward)
+    {
         m_canGoBack = canGoBack;
         m_canGoForward = canGoForward;
         m_wpeView.onTitleChanged(title);
     }
 
-    public void onInputMethodContextIn() {
-        InputMethodManager imm = (InputMethodManager) m_context.getSystemService(Context.INPUT_METHOD_SERVICE);
+    public void onInputMethodContextIn()
+    {
+        InputMethodManager imm = (InputMethodManager)m_context.getSystemService(Context.INPUT_METHOD_SERVICE);
         imm.toggleSoftInput(InputMethodManager.SHOW_FORCED, 0);
     }
 
-    private void dismissKeyboard() {
-        InputMethodManager imm = (InputMethodManager) m_context.getSystemService(Context.INPUT_METHOD_SERVICE);
+    private void dismissKeyboard()
+    {
+        InputMethodManager imm = (InputMethodManager)m_context.getSystemService(Context.INPUT_METHOD_SERVICE);
         imm.hideSoftInputFromWindow(m_view.getWindowToken(), 0);
     }
 
-    public void onInputMethodContextOut() {
+    public void onInputMethodContextOut()
+    {
         dismissKeyboard();
     }
 
-    public boolean canGoBack() {
+    public boolean canGoBack()
+    {
         return m_canGoBack;
     }
 
-    public boolean canGoForward() {
+    public boolean canGoForward()
+    {
         return m_canGoForward;
     }
 
-    public void goBack() {
+    public void goBack()
+    {
         if (m_pageGlueReady) {
             BrowserGlue.goBack(m_id);
         }
     }
 
-    public void goForward() {
+    public void goForward()
+    {
         if (m_pageGlueReady) {
             BrowserGlue.goForward(m_id);
         }
     }
 
-    public void stopLoading() {
+    public void stopLoading()
+    {
         if (m_pageGlueReady) {
             BrowserGlue.stopLoading(m_id);
         }
     }
 
-    public void reload() {
+    public void reload()
+    {
         if (m_pageGlueReady) {
             BrowserGlue.reload(m_id);
         }
     }
 
-    public void setInputMethodContent(char c) {
+    public void setInputMethodContent(char c)
+    {
         if (m_pageGlueReady) {
             BrowserGlue.setInputMethodContent(m_id, c);
         }
     }
 
-    public void deleteInputMethodContent(int offset) {
+    public void deleteInputMethodContent(int offset)
+    {
         if (m_pageGlueReady) {
             BrowserGlue.deleteInputMethodContent(m_id, offset);
         }

--- a/wpe/src/main/java/com/wpe/wpe/gfx/View.java
+++ b/wpe/src/main/java/com/wpe/wpe/gfx/View.java
@@ -2,26 +2,26 @@ package com.wpe.wpe.gfx;
 
 import android.content.Context;
 import android.util.Log;
-import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.ScaleGestureDetector;
 import android.view.SurfaceHolder;
 import android.view.SurfaceView;
 
-import androidx.annotation.Nullable;
 import androidx.annotation.UiThread;
 
 import com.wpe.wpe.BrowserGlue;
-import com.wpe.wpeview.SurfaceClient;
 import com.wpe.wpeview.WPEView;
 
 @UiThread
-public class View extends SurfaceView {
+public class View extends SurfaceView
+{
     private String LOGTAG;
 
-    private class ScaleListener extends ScaleGestureDetector.SimpleOnScaleGestureListener {
+    private class ScaleListener extends ScaleGestureDetector.SimpleOnScaleGestureListener
+    {
         @Override
-        public boolean onScale(ScaleGestureDetector detector) {
+        public boolean onScale(ScaleGestureDetector detector)
+        {
             mScaleFactor *= detector.getScaleFactor();
 
             mScaleFactor = Math.max(0.1f, Math.min(mScaleFactor, 5.0f));
@@ -34,7 +34,8 @@ public class View extends SurfaceView {
         }
     }
 
-    private static class HolderCallback implements SurfaceHolder.Callback2 {
+    private static class HolderCallback implements SurfaceHolder.Callback2
+    {
         private View m_view;
 
         HolderCallback(View view)
@@ -79,7 +80,8 @@ public class View extends SurfaceView {
     private float mScaleFactor = 1.f;
     private boolean m_ignoreTouchEvent = false;
 
-    public View(Context context, int pageId, WPEView wpeView) {
+    public View(Context context, int pageId, WPEView wpeView)
+    {
         super(context);
 
         LOGTAG = "WPE gfx.View" + pageId;
@@ -99,16 +101,19 @@ public class View extends SurfaceView {
         requestLayout();
     }
 
-    public int width() {
+    public int width()
+    {
         return m_width;
     }
 
-    public int height() {
+    public int height()
+    {
         return m_height;
     }
 
     @Override
-    public boolean onTouchEvent(MotionEvent event) {
+    public boolean onTouchEvent(MotionEvent event)
+    {
         int pointerCount = event.getPointerCount();
         if (pointerCount < 1) {
             return false;
@@ -124,17 +129,17 @@ public class View extends SurfaceView {
 
         int eventAction = event.getActionMasked();
         switch (eventAction) {
-            case MotionEvent.ACTION_DOWN:
-                eventType = 0;
-                break;
-            case MotionEvent.ACTION_MOVE:
-                eventType = 1;
-                break;
-            case MotionEvent.ACTION_UP:
-                eventType = 2;
-                break;
-            default:
-                return false;
+        case MotionEvent.ACTION_DOWN:
+            eventType = 0;
+            break;
+        case MotionEvent.ACTION_MOVE:
+            eventType = 1;
+            break;
+        case MotionEvent.ACTION_UP:
+            eventType = 2;
+            break;
+        default:
+            return false;
         }
 
         BrowserGlue.touchEvent(m_pageId, event.getEventTime(), eventType, event.getX(0), event.getY(0));

--- a/wpe/src/main/java/com/wpe/wpe/gfx/ViewObserver.java
+++ b/wpe/src/main/java/com/wpe/wpe/gfx/ViewObserver.java
@@ -1,6 +1,7 @@
 package com.wpe.wpe.gfx;
 
-public interface ViewObserver {
+public interface ViewObserver
+{
     void onViewCreated(View view);
     void onViewReady(View view);
 }

--- a/wpe/src/main/java/com/wpe/wpe/services/NetworkProcessGlue.java
+++ b/wpe/src/main/java/com/wpe/wpe/services/NetworkProcessGlue.java
@@ -1,6 +1,7 @@
 package com.wpe.wpe.services;
 
-public class NetworkProcessGlue {
+public class NetworkProcessGlue
+{
 
     static {
         System.loadLibrary("WPENetworkProcessGlue");

--- a/wpe/src/main/java/com/wpe/wpe/services/NetworkProcessService.java
+++ b/wpe/src/main/java/com/wpe/wpe/services/NetworkProcessService.java
@@ -6,7 +6,8 @@ import android.util.Log;
 
 import java.io.File;
 
-public class NetworkProcessService extends WPEService {
+public class NetworkProcessService extends WPEService
+{
     private static final String LOGTAG = "WPENetworkProcess";
 
     // Bump this version number if you make any changes to the gio

--- a/wpe/src/main/java/com/wpe/wpe/services/ServiceUtils.java
+++ b/wpe/src/main/java/com/wpe/wpe/services/ServiceUtils.java
@@ -10,10 +10,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-public class ServiceUtils {
+public class ServiceUtils
+{
     private static final String LOGTAG = "ServiceUtils";
 
-    public static void copyFileOrDir(Context context, AssetManager assetManager, String path) {
+    public static void copyFileOrDir(Context context, AssetManager assetManager, String path)
+    {
         String assets[] = null;
         try {
             assets = assetManager.list(path);
@@ -33,7 +35,8 @@ public class ServiceUtils {
         }
     }
 
-    private static void copyFile(Context context, AssetManager assetManager, String filename) {
+    private static void copyFile(Context context, AssetManager assetManager, String filename)
+    {
         InputStream in = null;
         OutputStream out = null;
         try {
@@ -57,17 +60,19 @@ public class ServiceUtils {
     // Tells whether we need to move the font config and gstreamer plugins to
     // the files dir. This is done only the first time WPEWebKit is launched or
     // everytime an update on these files is required
-    public static boolean needAssets(Context context, String assetsVersion) {
+    public static boolean needAssets(Context context, String assetsVersion)
+    {
         File file = new File(context.getFilesDir(), assetsVersion);
         return !file.exists();
     }
 
-    public static void saveAssetsVersion(Context context, String assetsVersion) {
+    public static void saveAssetsVersion(Context context, String assetsVersion)
+    {
         File file = new File(context.getFilesDir(), assetsVersion);
         if (!file.exists()) {
             try {
                 file.createNewFile();
-            } catch(IOException exception) {
+            } catch (IOException exception) {
                 Log.e(LOGTAG, "Could not save assets version. This will affect boot up performance");
             }
         }

--- a/wpe/src/main/java/com/wpe/wpe/services/WPEService.java
+++ b/wpe/src/main/java/com/wpe/wpe/services/WPEService.java
@@ -10,12 +10,15 @@ import android.util.Log;
 
 import com.wpe.wpe.IWPEService;
 
-public class WPEService extends Service {
+public class WPEService extends Service
+{
     private static final String LOGTAG = "WPEService";
 
-    public final IWPEService.Stub m_binder = new IWPEService.Stub() {
+    public final IWPEService.Stub m_binder = new IWPEService.Stub()
+    {
         @Override
-        public int connect(Bundle args) {
+        public int connect(Bundle args)
+        {
             Log.v(LOGTAG, "IWPEService.Stub connect()");
 
             Parcelable[] fdParcelables = args.getParcelableArray("fds");
@@ -27,17 +30,21 @@ public class WPEService extends Service {
         }
     };
 
-    protected class WPEServiceProcessThread {
+    protected class WPEServiceProcessThread
+    {
         private static final String LOGTAG = "WPEServiceProcessThread";
         private Thread m_thread;
         private WPEService m_service;
         private ParcelFileDescriptor[] m_serviceFds = null;
 
-        WPEServiceProcessThread() {
+        WPEServiceProcessThread()
+        {
             final WPEServiceProcessThread thisObj = this;
-            m_thread = new Thread(new Runnable() {
+            m_thread = new Thread(new Runnable()
+            {
                 @Override
-                public void run() {
+                public void run()
+                {
                     Log.v(LOGTAG, "Running");
 
                     while (true) {
@@ -71,7 +78,8 @@ public class WPEService extends Service {
     static protected WPEServiceProcessThread m_serviceProcessThread;
 
     @Override
-    public void onCreate() {
+    public void onCreate()
+    {
         Log.i(LOGTAG, "onCreate()");
         super.onCreate();
 
@@ -86,18 +94,21 @@ public class WPEService extends Service {
     }
 
     @Override
-    public IBinder onBind(Intent intent) {
+    public IBinder onBind(Intent intent)
+    {
         Log.i(LOGTAG, "onBind()");
         return m_binder;
     }
 
     @Override
-    public void onDestroy() {
+    public void onDestroy()
+    {
         Log.i(LOGTAG, "onDestroy()");
         super.onDestroy();
     }
 
-    private void provideServiceFDs(ParcelFileDescriptor[] fds) {
+    private void provideServiceFDs(ParcelFileDescriptor[] fds)
+    {
         synchronized (m_serviceProcessThread) {
             m_serviceProcessThread.m_serviceFds = fds;
             m_serviceProcessThread.notifyAll();

--- a/wpe/src/main/java/com/wpe/wpe/services/WPEServiceConnection.java
+++ b/wpe/src/main/java/com/wpe/wpe/services/WPEServiceConnection.java
@@ -10,7 +10,8 @@ import android.util.Log;
 import com.wpe.wpe.IWPEService;
 import com.wpe.wpe.Page;
 
-public class WPEServiceConnection implements ServiceConnection {
+public class WPEServiceConnection implements ServiceConnection
+{
     private static final String LOGTAG = "WPEServiceConnection";
 
     private final int m_processType;
@@ -33,7 +34,8 @@ public class WPEServiceConnection implements ServiceConnection {
      *        among Page instances. We need to set the Page instance this
      *        auxiliary process is working for.
      */
-    public void setActivePage(Page page) {
+    public void setActivePage(Page page)
+    {
         m_page = page;
     }
 
@@ -63,7 +65,8 @@ public class WPEServiceConnection implements ServiceConnection {
         m_page.stopService(this);
     }
 
-    public int processType() {
+    public int processType()
+    {
         return m_processType;
     }
 }

--- a/wpe/src/main/java/com/wpe/wpe/services/WPEServices.java.template
+++ b/wpe/src/main/java/com/wpe/wpe/services/WPEServices.java.template
@@ -3,6 +3,7 @@
 
 package com.wpe.wpe.services;
 
-public class WPEServices {
+public class WPEServices
+{
     // SERVICES PLACEHOLDER
 }

--- a/wpe/src/main/java/com/wpe/wpe/services/WebProcessGlue.java
+++ b/wpe/src/main/java/com/wpe/wpe/services/WebProcessGlue.java
@@ -1,7 +1,7 @@
 package com.wpe.wpe.services;
 
-public class WebProcessGlue {
-
+public class WebProcessGlue
+{
     static {
         System.loadLibrary("WPEBackend-default");
         System.loadLibrary("WPEWebProcessGlue");

--- a/wpe/src/main/java/com/wpe/wpe/services/WebProcessService.java
+++ b/wpe/src/main/java/com/wpe/wpe/services/WebProcessService.java
@@ -2,17 +2,13 @@ package com.wpe.wpe.services;
 
 import android.content.Context;
 import android.content.pm.ApplicationInfo;
-import android.content.res.AssetManager;
 import android.os.ParcelFileDescriptor;
 import android.util.Log;
 
 import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 
-public class WebProcessService extends WPEService {
+public class WebProcessService extends WPEService
+{
     private static final String LOGTAG = "WPEWebProcess";
     private boolean m_initialized = false;
 
@@ -34,19 +30,19 @@ public class WebProcessService extends WPEService {
         }
 
         String fontConfigPath = new File(context.getFilesDir(), "fontconfig")
-                .getAbsolutePath();
+            .getAbsolutePath();
         String gstreamerPath = new File(context.getFilesDir(), "gstreamer-1.0")
-                .getAbsolutePath();
+            .getAbsolutePath();
         String gioPath = new File(context.getFilesDir(), "gio").getAbsolutePath();
         ApplicationInfo appInfo = context.getApplicationInfo();
 
         WebProcessGlue.setupEnvironment(
-                fontConfigPath,
-                gstreamerPath,
-                gioPath,
-                appInfo.nativeLibraryDir,
-                context.getCacheDir().getAbsolutePath(),
-                context.getFilesDir().getAbsolutePath()
+            fontConfigPath,
+            gstreamerPath,
+            gioPath,
+            appInfo.nativeLibraryDir,
+            context.getCacheDir().getAbsolutePath(),
+            context.getFilesDir().getAbsolutePath()
         );
     }
 

--- a/wpe/src/main/java/com/wpe/wpeview/SurfaceClient.java
+++ b/wpe/src/main/java/com/wpe/wpeview/SurfaceClient.java
@@ -2,7 +2,8 @@ package com.wpe.wpeview;
 
 import android.view.SurfaceHolder;
 
-public interface SurfaceClient {
+public interface SurfaceClient
+{
     /**
      * Notify the host application to add a callback used to process Surface creation and update events.
      * @param view The WPEView that initiated the callback.

--- a/wpe/src/main/java/com/wpe/wpeview/WPEViewClient.java
+++ b/wpe/src/main/java/com/wpe/wpeview/WPEViewClient.java
@@ -1,6 +1,7 @@
 package com.wpe.wpeview;
 
-public interface WPEViewClient {
+public interface WPEViewClient
+{
     /**
      * Notify the host application that a page has started loading. This method
      * is called once for each main frame load so a page with iframes or

--- a/wpe/src/main/java/com/wpe/wpeview/WebChromeClient.java
+++ b/wpe/src/main/java/com/wpe/wpeview/WebChromeClient.java
@@ -1,6 +1,7 @@
 package com.wpe.wpeview;
 
-public interface WebChromeClient {
+public interface WebChromeClient
+{
     /**
      * Tell the host application the current progress of loading a page.
      * @param view The WPEView that initiated the callback.


### PR DESCRIPTION
- unify code style
- upgrade C-style calls to C++
- fix memory leaks when converting jstring to UTF8 const char*
- optimize java->native JNI calls by using RegisterNatives() instead of
exporting all functions
- set "final" classes with non-virtual destructor
- use nullptr instead of NULL
- rename deinit() function shut() (mispelling)
- use template function instead of macros to improve readability and
debuggability of PageEventObserver
- pre-register Java methods IDs in PageEventObserver
- fix possible Java exceptions when calling Java methods from native
code
- optimize JNIEnv fetching for native threads calls
- fix some warnings in Kotlin code
- fix colors in MiniBrowser example for dark themes