### PR TITLE
Introduce initial version of fullscreen support

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -132,7 +132,7 @@ public class com.wpe.wpe.Page {
     descriptor: Ljava/lang/String;
   private final com.wpe.wpe.BrowserGlue m_glue;
     descriptor: Lcom/wpe/wpe/BrowserGlue;
-  private final com.wpe.wpe.gfx.View m_view;
+  private final com.wpe.wpe.gfx.WPESurfaceView m_view;
     descriptor: Lcom/wpe/wpe/gfx/View;
   private final android.content.Context m_context;
     descriptor: Landroid/content/Context;
@@ -140,7 +140,7 @@ public class com.wpe.wpe.Page {
     descriptor: Ljava/util/ArrayList;
   private long m_webViewRef;
     descriptor: J
-  public com.wpe.wpe.Page(android.content.Context, java.lang.String, com.wpe.wpe.gfx.View, com.wpe.wpe.BrowserGlue);
+  public com.wpe.wpe.Page(android.content.Context, java.lang.String, com.wpe.wpe.gfx.WPESurfaceView, com.wpe.wpe.BrowserGlue);
     descriptor: (Landroid/content/Context;Ljava/lang/String;Lcom/wpe/wpe/gfx/View;Lcom/wpe/wpe/BrowserGlue;)V
 
   public void close();
@@ -158,7 +158,7 @@ public class com.wpe.wpe.Page {
   public void dropService(com.wpe.wpe.services.WPEServiceConnection);
     descriptor: (Lcom/wpe/wpe/services/WPEServiceConnection;)V
 
-  public com.wpe.wpe.gfx.View view();
+  public com.wpe.wpe.gfx.WPESurfaceView view();
     descriptor: ()Lcom/wpe/wpe/gfx/View;
 
   public void loadUrl(java.lang.String);

--- a/tools/minibrowser/README.md
+++ b/tools/minibrowser/README.md
@@ -1,0 +1,3 @@
+# MiniBrowser
+
+The MiniBrowser is a standalone application for testing WPEView.

--- a/tools/minibrowser/src/main/java/com/wpe/tools/minibrowser/Browser.kt
+++ b/tools/minibrowser/src/main/java/com/wpe/tools/minibrowser/Browser.kt
@@ -5,12 +5,10 @@ import android.content.res.Configuration
 import android.graphics.Color
 import android.os.Bundle
 import android.util.Log
-import android.view.KeyEvent
-import android.view.Menu
-import android.view.MenuItem
-import android.view.View
+import android.view.*
 import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
+import android.widget.FrameLayout
 import android.widget.ProgressBar
 import android.widget.TextView
 import androidx.appcompat.app.ActionBar
@@ -33,6 +31,8 @@ class MainActivity : AppCompatActivity(R.layout.activity_main) {
     private var activeTab: Tab? = null
     private var activeTabItem: TabSelectorItem? = null
     private var tabs: ArrayList<TabSelectorItem> = ArrayList()
+
+    private var fullscreenView: View? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -150,6 +150,30 @@ class MainActivity : AppCompatActivity(R.layout.activity_main) {
                 } else {
                     progressView.visibility = View.GONE
                 }
+            }
+
+            override fun onShowCustomView(view: View?, callback: WebChromeClient.CustomViewCallback?) {
+                fullscreenView?.let {
+                    (it.parent as ViewGroup).removeView(it)
+                }
+                fullscreenView = view
+                window.addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN)
+                window.addContentView(
+                    fullscreenView,
+                    FrameLayout.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.MATCH_PARENT, Gravity.CENTER
+                    )
+                )
+                callback?.onCustomViewHidden()
+            }
+
+            override fun onHideCustomView() {
+                fullscreenView?.let {
+                    window.clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN)
+                    (it.parent as ViewGroup).removeView(it)
+                }
+                fullscreenView = null
             }
         };
     }

--- a/wpe/src/main/cpp/browser/browser.cpp
+++ b/wpe/src/main/cpp/browser/browser.cpp
@@ -112,6 +112,7 @@ PAGE_METHOD_PROXY(stopLoading, stopLoading, G_PRIORITY_DEFAULT)
 PAGE_METHOD_PROXY(reload, reload, G_PRIORITY_DEFAULT)
 PAGE_METHOD_PROXY(surfaceRedrawNeeded, surfaceRedrawNeeded, G_PRIORITY_DEFAULT)
 PAGE_METHOD_PROXY(surfaceDestroyed, surfaceDestroyed, G_PRIORITY_DEFAULT)
+PAGE_METHOD_PROXY(requestExitFullscreen, requestExitFullscreen, G_PRIORITY_DEFAULT)
 
 void Browser::surfaceCreated(int pageId, ANativeWindow* window)
 {

--- a/wpe/src/main/cpp/browser/browser.h
+++ b/wpe/src/main/cpp/browser/browser.h
@@ -59,6 +59,8 @@ public:
     void setInputMethodContent(int pageId, const char c);
     void deleteInputMethodContent(int pageId, int offset);
 
+    void requestExitFullscreen(int pageId);
+
 private:
     Browser() = default;
 

--- a/wpe/src/main/cpp/browser/entrypoints.cpp
+++ b/wpe/src/main/cpp/browser/entrypoints.cpp
@@ -160,6 +160,12 @@ void deleteInputMethodContent(JNIEnv*, jclass, jint pageId, jint offset)
     ALOGV("BrowserGlue::deleteInputMethodContent(%d, %d) [tid %d]", pageId, offset, gettid());
     Browser::getInstance().deleteInputMethodContent(pageId, offset);
 }
+
+void requestExitFullscreenMode(JNIEnv*, jclass, jint pageId)
+{
+    ALOGV("BrowserGlue::requestExitFullscreen(%d) [tid %d]", pageId, gettid());
+    Browser::getInstance().requestExitFullscreen(pageId);
+}
 } // namespace
 
 JNIEXPORT void JNICALL wpe_android_launchProcess(uint64_t pid, int processType, int* fds)
@@ -235,25 +241,26 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* reserved)
         return JNI_ERR;
 
     static const JNINativeMethod methods[] = {
-            { "setupEnvironment",         "(Ljava/lang/String;)V",                      reinterpret_cast<void*>(setupEnvironment) },
-            { "init",                     "(Lcom/wpe/wpe/BrowserGlue;)V",               reinterpret_cast<void*>(init) },
-            { "initLooperHelper",         "()V",                                        reinterpret_cast<void*>(initLooperHelper) },
-            { "shut",                     "()V",                                        reinterpret_cast<void*>(shut) },
-            { "newPage",                  "(Lcom/wpe/wpe/Page;IIILjava/lang/String;)V", reinterpret_cast<void*>(newPage) },
-            { "closePage",                "(I)V",                                       reinterpret_cast<void*>(closePage) },
-            { "loadURL",                  "(ILjava/lang/String;)V",                     reinterpret_cast<void*>(loadURL) },
-            { "goBack",                   "(I)V",                                       reinterpret_cast<void*>(goBack) },
-            { "goForward",                "(I)V",                                       reinterpret_cast<void*>(goForward) },
-            { "stopLoading",              "(I)V",                                       reinterpret_cast<void*>(stopLoading) },
-            { "reload",                   "(I)V",                                       reinterpret_cast<void*>(reload) },
-            { "surfaceCreated",           "(ILandroid/view/Surface;)V",                 reinterpret_cast<void*>(surfaceCreated) },
-            { "surfaceChanged",           "(IIII)V",                                    reinterpret_cast<void*>(surfaceChanged) },
-            { "surfaceRedrawNeeded",      "(I)V",                                       reinterpret_cast<void*>(surfaceRedrawNeeded) },
-            { "surfaceDestroyed",         "(I)V",                                       reinterpret_cast<void*>(surfaceDestroyed) },
-            { "touchEvent",               "(IJIFF)V",                                   reinterpret_cast<void*>(touchEvent) },
-            { "setZoomLevel",             "(ID)V",                                      reinterpret_cast<void*>(setZoomLevel) },
-            { "setInputMethodContent",    "(IC)V",                                      reinterpret_cast<void*>(setInputMethodContent) },
-            { "deleteInputMethodContent", "(II)V",                                      reinterpret_cast<void*>(deleteInputMethodContent) }
+            { "setupEnvironment",          "(Ljava/lang/String;)V",                      reinterpret_cast<void*>(setupEnvironment) },
+            { "init",                      "(Lcom/wpe/wpe/BrowserGlue;)V",               reinterpret_cast<void*>(init) },
+            { "initLooperHelper",          "()V",                                        reinterpret_cast<void*>(initLooperHelper) },
+            { "shut",                      "()V",                                        reinterpret_cast<void*>(shut) },
+            { "newPage",                   "(Lcom/wpe/wpe/Page;IIILjava/lang/String;)V", reinterpret_cast<void*>(newPage) },
+            { "closePage",                 "(I)V",                                       reinterpret_cast<void*>(closePage) },
+            { "loadURL",                   "(ILjava/lang/String;)V",                     reinterpret_cast<void*>(loadURL) },
+            { "goBack",                    "(I)V",                                       reinterpret_cast<void*>(goBack) },
+            { "goForward",                 "(I)V",                                       reinterpret_cast<void*>(goForward) },
+            { "stopLoading",               "(I)V",                                       reinterpret_cast<void*>(stopLoading) },
+            { "reload",                    "(I)V",                                       reinterpret_cast<void*>(reload) },
+            { "surfaceCreated",            "(ILandroid/view/Surface;)V",                 reinterpret_cast<void*>(surfaceCreated) },
+            { "surfaceChanged",            "(IIII)V",                                    reinterpret_cast<void*>(surfaceChanged) },
+            { "surfaceRedrawNeeded",       "(I)V",                                       reinterpret_cast<void*>(surfaceRedrawNeeded) },
+            { "surfaceDestroyed",          "(I)V",                                       reinterpret_cast<void*>(surfaceDestroyed) },
+            { "touchEvent",                "(IJIFF)V",                                   reinterpret_cast<void*>(touchEvent) },
+            { "setZoomLevel",              "(ID)V",                                      reinterpret_cast<void*>(setZoomLevel) },
+            { "setInputMethodContent",     "(IC)V",                                      reinterpret_cast<void*>(setInputMethodContent) },
+            { "deleteInputMethodContent",  "(II)V",                                      reinterpret_cast<void*>(deleteInputMethodContent) },
+            { "requestExitFullscreenMode", "(I)V",                                       reinterpret_cast<void*>(requestExitFullscreenMode) }
     };
     int result = env->RegisterNatives(klass, methods, sizeof(methods) / sizeof(JNINativeMethod));
     env->DeleteLocalRef(klass);

--- a/wpe/src/main/cpp/browser/page.h
+++ b/wpe/src/main/cpp/browser/page.h
@@ -46,6 +46,10 @@ public:
     void setInputMethodContent(const char c);
     void deleteInputMethodContent(int offset);
 
+    void domFullscreenRequest(bool fullscreen);
+    void requestExitFullscreen();
+    void fullscreenImageReady();
+
     struct wpe_android_view_backend_exportable* exportable()
     { return m_viewBackendExportable; }
 
@@ -56,6 +60,7 @@ private:
     int m_height = 0;
     std::string m_userAgent;
     bool m_initialized = false;
+    bool m_resizing_fullscreen = false;
     WebKitWebView* m_webView = nullptr;
     struct wpe_android_view_backend_exportable* m_viewBackendExportable = nullptr;
     std::unique_ptr<Renderer> m_renderer;

--- a/wpe/src/main/cpp/browser/pageeventobserver.cpp
+++ b/wpe/src/main/cpp/browser/pageeventobserver.cpp
@@ -13,7 +13,9 @@ enum class JavaMethodTag : int
     ON_URI_CHANGED,
     ON_TITLE_CHANGED,
     ON_INPUT_METHOD_CONTEXT_IN,
-    ON_INPUT_METHOD_CONTEXT_OUT
+    ON_INPUT_METHOD_CONTEXT_OUT,
+    ENTER_FULLSCREEN_MODE,
+    EXIT_FULLSCREEN_MODE
 };
 
 struct JavaMethodDesc
@@ -28,7 +30,9 @@ constexpr JavaMethodDesc javaMethods[PageEventObserver::NB_JAVA_METHODS] = {
         { "onUriChanged",            "(Ljava/lang/String;)V" },
         { "onTitleChanged",          "(Ljava/lang/String;ZZ)V" },
         { "onInputMethodContextIn",  "()V" },
-        { "onInputMethodContextOut", "()V" }
+        { "onInputMethodContextOut", "()V" },
+        { "enterFullscreenMode",     "()V" },
+        { "exitFullscreenMode",      "()V" }
 };
 }; // namespace
 
@@ -119,4 +123,14 @@ void PageEventObserver::onInputMethodContextIn()
 void PageEventObserver::onInputMethodContextOut()
 {
     callJavaVoidMethod(static_cast<int>(JavaMethodTag::ON_INPUT_METHOD_CONTEXT_OUT));
+}
+
+void PageEventObserver::enterFullscreenMode()
+{
+    callJavaVoidMethod(static_cast<int>(JavaMethodTag::ENTER_FULLSCREEN_MODE));
+}
+
+void PageEventObserver::exitFullscreenMode()
+{
+    callJavaVoidMethod(static_cast<int>(JavaMethodTag::EXIT_FULLSCREEN_MODE));
 }

--- a/wpe/src/main/cpp/browser/pageeventobserver.h
+++ b/wpe/src/main/cpp/browser/pageeventobserver.h
@@ -14,7 +14,7 @@ public:
     PageEventObserver(const PageEventObserver&) = delete;
     PageEventObserver& operator=(const PageEventObserver&) = delete;
 
-    static constexpr int NB_JAVA_METHODS = 6;
+    static constexpr int NB_JAVA_METHODS = 8;
 
     void onLoadChanged(WebKitLoadEvent loadEvent);
     void onLoadProgress(double progress);
@@ -23,6 +23,9 @@ public:
 
     void onInputMethodContextIn();
     void onInputMethodContextOut();
+
+    void enterFullscreenMode();
+    void exitFullscreenMode();
 
 private:
     template<typename... Args>

--- a/wpe/src/main/cpp/browser/renderer.h
+++ b/wpe/src/main/cpp/browser/renderer.h
@@ -9,6 +9,9 @@ class Renderer
 public:
     virtual ~Renderer() = default;
 
+    virtual int width() const = 0;
+    virtual int height() const = 0;
+
     virtual void surfaceCreated(ANativeWindow*) = 0;
     virtual void surfaceChanged(int format, unsigned width, unsigned height) = 0;
     virtual void surfaceRedrawNeeded() = 0;

--- a/wpe/src/main/cpp/browser/renderer_asurfacetransaction.cpp
+++ b/wpe/src/main/cpp/browser/renderer_asurfacetransaction.cpp
@@ -54,8 +54,6 @@ void RendererASurfaceTransaction::surfaceCreated(ANativeWindow* window)
 void RendererASurfaceTransaction::surfaceChanged(int format, unsigned width, unsigned height)
 {
     // Update the size.
-    // FIXME: currently neither the format nor the stored size are used anywhere.
-    // https://github.com/Igalia/wpe-android/issues/36
     m_size.width = width;
     m_size.height = height;
 }

--- a/wpe/src/main/cpp/browser/renderer_asurfacetransaction.h
+++ b/wpe/src/main/cpp/browser/renderer_asurfacetransaction.h
@@ -18,6 +18,9 @@ public:
     RendererASurfaceTransaction(Page&, unsigned width, unsigned height);
     virtual ~RendererASurfaceTransaction();
 
+    int width() const override { return m_size.width; }
+    int height() const override { return m_size.height; }
+
     virtual void surfaceCreated(ANativeWindow*) override;
     virtual void surfaceChanged(int format, unsigned width, unsigned height) override;
     virtual void surfaceRedrawNeeded() override;

--- a/wpe/src/main/cpp/browser/renderer_fallback.h
+++ b/wpe/src/main/cpp/browser/renderer_fallback.h
@@ -15,6 +15,9 @@ public:
     RendererFallback(Page&, unsigned width, unsigned height);
     virtual ~RendererFallback();
 
+    int width() const override { return m_size.width; }
+    int height() const override { return m_size.height; }
+
     virtual void surfaceCreated(ANativeWindow*) override;
     virtual void surfaceChanged(int format, unsigned width, unsigned height) override;
     virtual void surfaceRedrawNeeded() override;

--- a/wpe/src/main/java/com/wpe/wpe/Browser.java
+++ b/wpe/src/main/java/com/wpe/wpe/Browser.java
@@ -537,4 +537,12 @@ public final class Browser
         }
         m_pages.get(wpeView).deleteInputMethodContent(offset);
     }
+
+    public void requestExitFullscreenMode(@NonNull WPEView wpeView)
+    {
+        if (m_pages == null || !m_pages.containsKey(wpeView)) {
+            return;
+        }
+        m_pages.get(wpeView).requestExitFullscreenMode();
+    }
 }

--- a/wpe/src/main/java/com/wpe/wpe/BrowserGlue.java
+++ b/wpe/src/main/java/com/wpe/wpe/BrowserGlue.java
@@ -45,6 +45,8 @@ public class BrowserGlue
     public static native void setInputMethodContent(int pageId, char c);
     public static native void deleteInputMethodContent(int m_id, int offset);
 
+    public static native void requestExitFullscreenMode(int pageId);
+
     public BrowserGlue(@NonNull Browser browser)
     {
         m_browser = browser;

--- a/wpe/src/main/java/com/wpe/wpe/Page.java
+++ b/wpe/src/main/java/com/wpe/wpe/Page.java
@@ -11,7 +11,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.UiThread;
 import androidx.annotation.WorkerThread;
 
-import com.wpe.wpe.gfx.View;
+import com.wpe.wpe.gfx.WPESurfaceView;
 import com.wpe.wpe.services.WPEServiceConnection;
 import com.wpe.wpeview.WPEView;
 
@@ -46,7 +46,7 @@ public class Page
     private final int m_width;
     private final int m_height;
 
-    private View m_view;
+    private WPESurfaceView m_view;
     private boolean m_viewReady = false;
 
     private boolean m_pageGlueReady = false;
@@ -103,8 +103,8 @@ public class Page
         m_width = wpeView.getMeasuredWidth();
         m_height = wpeView.getMeasuredHeight();
 
-        m_view = new View(m_context, pageId, wpeView);
-        m_wpeView.onViewCreated(m_view);
+        m_view = new WPESurfaceView(m_context, pageId, wpeView);
+        m_wpeView.onSurfaceViewCreated(m_view);
         onViewReady();
 
         ensurePageGlue();
@@ -155,7 +155,7 @@ public class Page
     public void onViewReady()
     {
         Log.d(LOGTAG, "onViewReady");
-        m_wpeView.onViewReady(m_view);
+        m_wpeView.onSurfaceViewReady(m_view);
         m_viewReady = true;
         if (m_pageGlueReady) {
             loadUrlInternal();
@@ -194,7 +194,7 @@ public class Page
         // FIXME: Until we fully support PSON, we won't do anything here.
     }
 
-    public View view()
+    public WPESurfaceView view()
     {
         return m_view;
     }
@@ -255,6 +255,25 @@ public class Page
     public void onInputMethodContextOut()
     {
         dismissKeyboard();
+    }
+
+    public void enterFullscreenMode()
+    {
+        Log.v(LOGTAG, "enterFullscreenMode");
+        m_wpeView.enterFullScreen();
+    }
+
+    public void exitFullscreenMode()
+    {
+        Log.v(LOGTAG, "exitFullscreenMode");
+        m_wpeView.exitFullScreen();
+    }
+
+    public void requestExitFullscreenMode()
+    {
+        if (m_pageGlueReady) {
+            BrowserGlue.requestExitFullscreenMode(m_id);
+        }
     }
 
     public boolean canGoBack()

--- a/wpe/src/main/java/com/wpe/wpe/gfx/ViewObserver.java
+++ b/wpe/src/main/java/com/wpe/wpe/gfx/ViewObserver.java
@@ -1,7 +1,0 @@
-package com.wpe.wpe.gfx;
-
-public interface ViewObserver
-{
-    void onViewCreated(View view);
-    void onViewReady(View view);
-}

--- a/wpe/src/main/java/com/wpe/wpe/gfx/WPESurfaceView.java
+++ b/wpe/src/main/java/com/wpe/wpe/gfx/WPESurfaceView.java
@@ -13,7 +13,7 @@ import com.wpe.wpe.BrowserGlue;
 import com.wpe.wpeview.WPEView;
 
 @UiThread
-public class View extends SurfaceView
+public class WPESurfaceView extends SurfaceView
 {
     private String LOGTAG;
 
@@ -34,18 +34,18 @@ public class View extends SurfaceView
         }
     }
 
-    private static class HolderCallback implements SurfaceHolder.Callback2
+    private static class SurfaceHolderCallback implements SurfaceHolder.Callback2
     {
-        private View m_view;
+        private WPESurfaceView m_view;
 
-        HolderCallback(View view)
+        SurfaceHolderCallback(WPESurfaceView view)
         {
             m_view = view;
         }
 
         public void surfaceChanged(SurfaceHolder holder, int format, int width, int height)
         {
-            Log.d(m_view.LOGTAG, "HolderCallback::surfaceChanged() format " + format + " (" + width + "," + height + ")");
+            Log.d(m_view.LOGTAG, "SurfaceHolderCallback::surfaceChanged() format " + format + " (" + width + "," + height + ")");
             synchronized (m_view) {
                 m_view.m_width = width;
                 m_view.m_height = height;
@@ -56,19 +56,19 @@ public class View extends SurfaceView
 
         public void surfaceCreated(SurfaceHolder holder)
         {
-            Log.d(m_view.LOGTAG, "HolderCallback::surfaceCreated()");
+            Log.d(m_view.LOGTAG, "SurfaceHolderCallback::surfaceCreated()");
             BrowserGlue.surfaceCreated(m_view.m_pageId, holder.getSurface());
         }
 
         public void surfaceDestroyed(SurfaceHolder holder)
         {
-            Log.d(m_view.LOGTAG, "HolderCallback::surfaceDestroyed()");
+            Log.d(m_view.LOGTAG, "SurfaceHolderCallback::surfaceDestroyed()");
             BrowserGlue.surfaceDestroyed(m_view.m_pageId);
         }
 
         public void surfaceRedrawNeeded(SurfaceHolder holder)
         {
-            Log.d(m_view.LOGTAG, "HolderCallback::surfaceRedrawNeeded()");
+            Log.d(m_view.LOGTAG, "SurfaceHolderCallback::surfaceRedrawNeeded()");
             BrowserGlue.surfaceRedrawNeeded(m_view.m_pageId);
         }
     }
@@ -80,20 +80,20 @@ public class View extends SurfaceView
     private float mScaleFactor = 1.f;
     private boolean m_ignoreTouchEvent = false;
 
-    public View(Context context, int pageId, WPEView wpeView)
+    public WPESurfaceView(Context context, int pageId, WPEView wpeView)
     {
         super(context);
 
-        LOGTAG = "WPE gfx.View" + pageId;
+        LOGTAG = "WPE gfx.WPESurfaceView" + pageId;
 
         m_pageId = pageId;
 
         if (wpeView.getSurfaceClient() != null) {
-            wpeView.getSurfaceClient().addCallback(wpeView, new HolderCallback(this));
+            wpeView.getSurfaceClient().addCallback(wpeView, new SurfaceHolderCallback(this));
         } else {
             SurfaceHolder holder = getHolder();
-            Log.d(LOGTAG, "View: holder " + holder);
-            holder.addCallback(new HolderCallback(this));
+            Log.d(LOGTAG, "WPESurfaceView: holder " + holder);
+            holder.addCallback(new SurfaceHolderCallback(this));
         }
 
         mScaleDetector = new ScaleGestureDetector(context, new ScaleListener());

--- a/wpe/src/main/java/com/wpe/wpe/gfx/WPESurfaceViewObserver.java
+++ b/wpe/src/main/java/com/wpe/wpe/gfx/WPESurfaceViewObserver.java
@@ -1,0 +1,7 @@
+package com.wpe.wpe.gfx;
+
+public interface WPESurfaceViewObserver
+{
+    void onSurfaceViewCreated(WPESurfaceView view);
+    void onSurfaceViewReady(WPESurfaceView view);
+}

--- a/wpe/src/main/java/com/wpe/wpeview/WebChromeClient.java
+++ b/wpe/src/main/java/com/wpe/wpeview/WebChromeClient.java
@@ -1,5 +1,7 @@
 package com.wpe.wpeview;
 
+import android.view.View;
+
 public interface WebChromeClient
 {
     /**
@@ -16,4 +18,30 @@ public interface WebChromeClient
      * @param title A String containing the new title of the document.
      */
     default void onReceivedTitle(WPEView view, String title) {}
+
+    /**
+     * A callback interface used by the host application to notify
+     * the current page that its custom view has been dismissed.
+     */
+    interface CustomViewCallback
+    {
+        /**
+         * Invoked when the host application dismisses the
+         * custom view.
+         */
+        void onCustomViewHidden();
+    }
+
+    /**
+     * Notify the host application that the current page has entered full screen mode.
+     * @param view is the View object to be shown.
+     * @param callback invoke this callback to request the page to exit
+     * full screen mode.
+     */
+    default void onShowCustomView(View view, WebChromeClient.CustomViewCallback callback) {}
+
+    /**
+     * Notify the host application that the current page has exited full screen mode.
+     */
+    default void onHideCustomView() {}
 }


### PR DESCRIPTION
This version is trivial version of fullscreen support. This puts API in place but implementation will be improved later on along with graphics stack and other feature improvements.

- Implements fullscreen support and API similar to Android WebView
- Renames com.wpe.wpe.gfx.View to com.wpe.wpe.gfx.WPESurfaceView to avoid confusion with android.view.View

Fixes #1 
Depends on https://github.com/Igalia/cerbero/pull/18