### PR TITLE
bootstrap: Avoid using a symlink for the backend library

### DIFF
--- a/tools/scripts/bootstrap.py
+++ b/tools/scripts/bootstrap.py
@@ -347,7 +347,9 @@ class Bootstrap:
         for lib_path in Path(target_dir).rglob("*.so"):
             self._replace_soname_values(lib_path)
 
-        os.symlink("libWPEBackend-android.so", os.path.join(target_dir, "libWPEBackend-default.so"))
+        backend_path = Path(target_dir, "libWPEBackend-android.so")
+        backend_path.replace(backend_path.with_name("libWPEBackend-default.so"))
+
         shutil.copytree(os.path.join(sysroot_lib_dir, "glib-2.0"), os.path.join(target_dir, "glib-2.0"))
 
     def _copy_jni_libs(self, src_dir, target_dir):


### PR DESCRIPTION
Rename `libWPEBackend-android.so` into `libWPEBackend-default.so` in order to avoid using a symlink. There is no need to include the file in the generated packages with the `libWPEBackend-android.so` name, so this change is harmless and sidesteps some potential failure modes (symlinks
not supported at build time, dynamic linker rejecting symlinks, etc.)