### PR TITLE
Rename WebChromeClient to WPEChromeClient

### DIFF
--- a/tools/minibrowser/src/main/java/com/wpe/tools/minibrowser/Browser.kt
+++ b/tools/minibrowser/src/main/java/com/wpe/tools/minibrowser/Browser.kt
@@ -20,7 +20,7 @@ import androidx.fragment.app.commit
 import com.google.android.material.color.MaterialColors
 import com.wpe.wpeview.WPEView
 import com.wpe.wpeview.WPEViewClient
-import com.wpe.wpeview.WebChromeClient
+import com.wpe.wpeview.WPEChromeClient
 
 const val INITIAL_URL = "https://igalia.com"
 const val SEARCH_URI_BASE = "https://duckduckgo.com/?q="
@@ -142,7 +142,7 @@ class MainActivity : AppCompatActivity(R.layout.activity_main) {
     }
 
     private fun setChromeClient() {
-        activeTab?.view?.webChromeClient = object : WebChromeClient {
+        activeTab?.view?.wpeChromeClient = object : WPEChromeClient {
             override fun onProgressChanged(view: WPEView?, progress: Int) {
                 super.onProgressChanged(view, progress)
                 progressView.progress = progress
@@ -153,7 +153,7 @@ class MainActivity : AppCompatActivity(R.layout.activity_main) {
                 }
             }
 
-            override fun onShowCustomView(view: View?, callback: WebChromeClient.CustomViewCallback?) {
+            override fun onShowCustomView(view: View?, callback: WPEChromeClient.CustomViewCallback?) {
                 fullscreenView?.let {
                     (it.parent as ViewGroup).removeView(it)
                 }

--- a/wpe/src/main/java/com/wpe/wpeview/WPEChromeClient.java
+++ b/wpe/src/main/java/com/wpe/wpeview/WPEChromeClient.java
@@ -2,7 +2,7 @@ package com.wpe.wpeview;
 
 import android.view.View;
 
-public interface WebChromeClient {
+public interface WPEChromeClient {
     /**
      * Tell the host application the current progress of loading a page.
      *
@@ -27,7 +27,7 @@ public interface WebChromeClient {
      * @param callback invoke this callback to request the page to exit
      * full screen mode.
      */
-    default void onShowCustomView(View view, WebChromeClient.CustomViewCallback callback) {}
+    default void onShowCustomView(View view, WPEChromeClient.CustomViewCallback callback) {}
 
     /**
      * Notify the host application that the current page has exited full screen mode.

--- a/wpe/src/main/java/com/wpe/wpeview/WPEView.java
+++ b/wpe/src/main/java/com/wpe/wpeview/WPEView.java
@@ -10,7 +10,6 @@ import android.widget.FrameLayout;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.UiThread;
-import androidx.annotation.WorkerThread;
 
 import com.wpe.wpe.Browser;
 import com.wpe.wpe.Page;
@@ -31,7 +30,7 @@ public class WPEView extends FrameLayout implements WPESurfaceViewObserver {
     private final Context context;
     private final WPESettings settings = new WPESettings();
 
-    private WebChromeClient chromeClient;
+    private WPEChromeClient wpeChromeClient;
     private WPEViewClient wpeViewClient;
     private SurfaceClient surfaceClient;
     private int currentLoadProgress = 0;
@@ -137,20 +136,20 @@ public class WPEView extends FrameLayout implements WPESurfaceViewObserver {
 
     public void onLoadProgress(double progress) {
         currentLoadProgress = (int)(progress * 100);
-        if (chromeClient == null) {
+        if (wpeChromeClient == null) {
             return;
         }
-        chromeClient.onProgressChanged(this, currentLoadProgress);
+        wpeChromeClient.onProgressChanged(this, currentLoadProgress);
     }
 
     public void onUriChanged(String uri) { url = uri; }
 
     public void onTitleChanged(String title) {
         this.title = title;
-        if (chromeClient == null) {
+        if (wpeChromeClient == null) {
             return;
         }
-        chromeClient.onReceivedTitle(this, title);
+        wpeChromeClient.onReceivedTitle(this, title);
     }
 
     public void enterFullScreen() {
@@ -161,7 +160,7 @@ public class WPEView extends FrameLayout implements WPESurfaceViewObserver {
         customView.setFocusable(true);
         customView.setFocusableInTouchMode(true);
 
-        chromeClient.onShowCustomView(customView, () -> {
+        wpeChromeClient.onShowCustomView(customView, () -> {
             if (customView != null) {
                 Browser.getInstance().requestExitFullscreenMode(WPEView.this);
             }
@@ -174,7 +173,7 @@ public class WPEView extends FrameLayout implements WPESurfaceViewObserver {
             addView(wpeSurfaceView);
             customView = null;
 
-            chromeClient.onHideCustomView();
+            wpeChromeClient.onHideCustomView();
         }
     }
 
@@ -267,23 +266,23 @@ public class WPEView extends FrameLayout implements WPESurfaceViewObserver {
     /**
      * Gets the chrome handler.
      *
-     * @return the WebChromeClient, or {@code null} if not yet set
-     * @see #setWebChromeClient
+     * @return the WPEChromeClient, or {@code null} if not yet set
+     * @see #setWPEChromeClient
      */
     @Nullable
-    public WebChromeClient getWebChromeClient() {
-        return chromeClient;
+    public WPEChromeClient getWPEChromeClient() {
+        return wpeChromeClient;
     }
 
     /**
-     * Sets the chrome handler. This is an implementation of WebChromeClient for
+     * Sets the chrome handler. This is an implementation of WPEChromeClient for
      * use in handling JavaScript dialogs, favicons, titles, and the progress.
      * This will replace the current handler.
      *
-     * @param client an implementation of WebChromeClient
-     * @see #getWebChromeClient
+     * @param client an implementation of WPEChromeClient
+     * @see #getWPEChromeClient
      */
-    public void setWebChromeClient(@Nullable WebChromeClient client) { chromeClient = client; }
+    public void setWPEChromeClient(@Nullable WPEChromeClient client) { wpeChromeClient = client; }
 
     /**
      * Gets the WPEViewClient.


### PR DESCRIPTION
Renaming to avoid confusion with Android system webview API WebChromeClient