### PR TITLE
Move webkit context and datamanager to browser singleton

### DIFF
--- a/wpe/src/main/cpp/Browser/Browser.cpp
+++ b/wpe/src/main/cpp/Browser/Browser.cpp
@@ -36,18 +36,23 @@
 #include <android/hardware_buffer.h>
 #include <android/surface_control.h>
 
-void Browser::init()
+void Browser::init(std::string dataDir, std::string cacheDir)
 {
     ALOGV("Browser::init - tid: %d", gettid());
 
     m_messagePump = std::make_unique<MessagePump>();
-    webkit_web_context_new();
+    m_websiteDataManager = webkit_website_data_manager_new(
+        "base-data-directory", dataDir.c_str(), "base-cache-directory", cacheDir.c_str(), NULL);
+    m_webContext = webkit_web_context_new_with_website_data_manager(m_websiteDataManager);
 }
 
 void Browser::shut()
 {
     ALOGV("Browser::shut - tid: %d", gettid());
     m_messagePump->quit();
+
+    g_clear_object(&m_webContext);
+    g_clear_object(&m_websiteDataManager);
 }
 
 void Browser::invokeOnUiThread(void (*callback)(void*), void* callbackData, void (*destroy)(void*))

--- a/wpe/src/main/cpp/Browser/Browser.h
+++ b/wpe/src/main/cpp/Browser/Browser.h
@@ -39,7 +39,7 @@ struct ANativeWindow;
 
 class Browser final {
 public:
-    static Browser& getInstance()
+    static Browser& instance()
     {
         static std::unique_ptr<Browser> singleton(new Browser());
         return *singleton;
@@ -52,7 +52,9 @@ public:
 
     ~Browser() { shut(); }
 
-    void init();
+    WebKitWebContext* webContext() const { return m_webContext; }
+
+    void init(std::string dataDir, std::string cacheDir);
     void shut();
 
     void invokeOnUiThread(void (*callback)(void*), void* callbackData, void (*destroy)(void*));
@@ -63,4 +65,7 @@ private:
     Browser() = default;
 
     std::unique_ptr<MessagePump> m_messagePump;
+
+    WebKitWebsiteDataManager* m_websiteDataManager = nullptr;
+    WebKitWebContext* m_webContext = nullptr;
 };

--- a/wpe/src/main/cpp/Browser/Page.h
+++ b/wpe/src/main/cpp/Browser/Page.h
@@ -40,7 +40,7 @@ struct ExportedBuffer;
 
 class Page final {
 public:
-    Page(std::string dataDir, std::string cacheDir, int width, int height, std::shared_ptr<PageEventObserver> observer);
+    Page(int width, int height, std::shared_ptr<PageEventObserver> observer);
 
     Page(Page&&) = delete;
     Page& operator=(Page&&) = delete;
@@ -83,15 +83,11 @@ public:
 private:
     static struct wpe_android_view_backend_exportable_client s_exportableClient;
 
-    std::string m_dataDir;
-    std::string m_cacheDir;
     int m_width = 0;
     int m_height = 0;
     bool m_initialized = false;
     bool m_resizing_fullscreen = false;
 
-    WebKitWebsiteDataManager* m_websiteDataManager = nullptr;
-    WebKitWebContext* m_webContext = nullptr;
     WebKitWebView* m_webView = nullptr;
     struct wpe_android_view_backend_exportable* m_viewBackendExportable = nullptr;
 

--- a/wpe/src/main/cpp/Browser/RendererASurfaceTransaction.cpp
+++ b/wpe/src/main/cpp/Browser/RendererASurfaceTransaction.cpp
@@ -158,7 +158,7 @@ void RendererASurfaceTransaction::onTransactionCompleteOnAnyThread(void* data, A
     ALOGV("RendererASurfaceTransaction::onTransactionCompleteOnAnyThread() context %p tid: %d", data, gettid());
 
     // Relay the transaction completion to the webkit ui thread.
-    Browser::getInstance().invokeOnUiThread(
+    Browser::instance().invokeOnUiThread(
         [](void* data) {
             auto* context = static_cast<TransactionContext*>(data);
             context->renderer.finishFrame(context->buffer);

--- a/wpe/src/main/java/com/wpe/wpe/Browser.java
+++ b/wpe/src/main/java/com/wpe/wpe/Browser.java
@@ -129,7 +129,7 @@ public final class Browser {
         BrowserGlue.setupEnvironment(envStringsArray);
 
         // Create a WebKitWebContext and integrate webkit main loop with Android looper
-        BrowserGlue.init(glue);
+        BrowserGlue.init(glue, context.getDataDir().getAbsolutePath(), context.getCacheDir().getAbsolutePath());
         initialized = true;
     }
 

--- a/wpe/src/main/java/com/wpe/wpe/BrowserGlue.java
+++ b/wpe/src/main/java/com/wpe/wpe/BrowserGlue.java
@@ -44,7 +44,7 @@ public class BrowserGlue {
     public BrowserGlue(@NonNull Browser browser) { this.browser = browser; }
 
     public static native void setupEnvironment(String[] envStringsArray);
-    public static native void init(BrowserGlue self);
+    public static native void init(BrowserGlue self, String dataDir, String cacheDir);
     public static native void initLooperHelper();
     public static native void shut();
 

--- a/wpe/src/main/java/com/wpe/wpe/Page.java
+++ b/wpe/src/main/java/com/wpe/wpe/Page.java
@@ -75,7 +75,7 @@ public class Page {
     private boolean ignoreTouchEvent = false;
 
     private long nativePtr;
-    private native void nativeInit(String dataDir, String cacheDir, int width, int height);
+    private native void nativeInit(int width, int height);
     private native void nativeClose();
     private native void nativeDestroy();
     private native void nativeLoadUrl(String url);
@@ -125,7 +125,7 @@ public class Page {
     }
 
     public void init() {
-        nativeInit(context.getDataDir().getAbsolutePath(), context.getCacheDir().getAbsolutePath(), width, height);
+        nativeInit(width, height);
         wpeView.onPageSurfaceViewCreated(surfaceView);
         wpeView.onPageSurfaceViewReady(surfaceView);
 


### PR DESCRIPTION
This is done in preparation to match WPEView API with Android system webview API. Android system webview considers similar entities as app wide instances.

This commit also changes Browser::getInstance() to Browser::instance() according to webkit code style

"Precede setters with the word “set”. Use bare words for getters"