### PR TITLE
Do not restart service in case of crash or auxiliary process direct exit

### DIFF
--- a/wpe/src/main/java/com/wpe/wpe/services/WPEService.java
+++ b/wpe/src/main/java/com/wpe/wpe/services/WPEService.java
@@ -27,6 +27,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.os.IBinder;
 import android.os.ParcelFileDescriptor;
+import android.os.Process;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
@@ -72,12 +73,13 @@ public abstract class WPEService extends Service {
     @Override
     public IBinder onBind(Intent intent) {
         Log.i(LOGTAG, "onBind()");
+        stopSelf();
         return binder;
     }
 
     @Override
     public void onDestroy() {
         Log.i(LOGTAG, "onDestroy()");
-        super.onDestroy();
+        Process.killProcess(Process.myPid());
     }
 }

--- a/wpe/src/main/java/com/wpe/wpe/services/WPEServiceConnection.java
+++ b/wpe/src/main/java/com/wpe/wpe/services/WPEServiceConnection.java
@@ -43,12 +43,17 @@ public final class WPEServiceConnection implements ServiceConnection {
     private final ProcessType processType;
     private ParcelFileDescriptor parcelFd;
 
-    public WPEServiceConnection(long pid, @NonNull ProcessType processType, @NonNull ParcelFileDescriptor parcelFd) {
+    private final WPEServiceConnectionDelegate delegate;
+
+    public WPEServiceConnection(long pid, @NonNull ProcessType processType, @NonNull ParcelFileDescriptor parcelFd,
+                                @NonNull WPEServiceConnectionDelegate delegate) {
         this.pid = pid;
         this.processType = processType;
         this.parcelFd = parcelFd;
+        this.delegate = delegate;
     }
 
+    public long getPid() { return pid; }
     public ProcessType getProcessType() { return processType; }
 
     @Override
@@ -76,7 +81,7 @@ public final class WPEServiceConnection implements ServiceConnection {
     @Override
     public void onServiceDisconnected(@NonNull ComponentName name) {
         Log.i(LOGTAG, "onServiceDisconnected() name: " + name);
-        // FIXME: We need to notify WebKit about the Service being killed.
-        //        What should WebKit do in this case?
+
+        delegate.onServiceDisconnected(this);
     }
 }

--- a/wpe/src/main/java/com/wpe/wpe/services/WPEServiceConnectionDelegate.java
+++ b/wpe/src/main/java/com/wpe/wpe/services/WPEServiceConnectionDelegate.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (C) 2022 Igalia S.L. <info@igalia.com>
+ *   Author: Jani Hautakangas <jani@igalia.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package com.wpe.wpe.services;
+
+public interface WPEServiceConnectionDelegate {
+    void onServiceDisconnected(WPEServiceConnection connection);
+}


### PR DESCRIPTION
In some cases WebProcess and NetworkProcess call exit(0) directly and in such cases Android tries to restart bound service. This is wrong because it's not Android system that should restart auxiliary processes but WebKit.

Fixes #138 138