### PR TITLE
Do not destroy WebKit view on onDetachedFromWindow call

### DIFF
--- a/wpe/src/main/java/com/wpe/wpeview/WPEView.java
+++ b/wpe/src/main/java/com/wpe/wpeview/WPEView.java
@@ -87,12 +87,6 @@ public class WPEView extends FrameLayout implements PageObserver {
     }
 
     @Override
-    protected void onDetachedFromWindow() {
-        super.onDetachedFromWindow();
-        page.destroy(); // TODO: This is probably not right
-    }
-
-    @Override
     public void onPageSurfaceViewCreated(SurfaceView view) {
         Log.v(LOGTAG, "onSurfaceViewCreated " + view + " number of views " + getChildCount());
         surfaceView = view;


### PR DESCRIPTION
onDetachedFromWindow call can happen when fragment is changed. For example going from webpage to browser settings. This should not destroy underlying webkit page instance.