### PR TITLE
Do not crash on webpage close

### DIFF
--- a/wpe/src/main/aidl/com/wpe/wpe/IWPEService.aidl
+++ b/wpe/src/main/aidl/com/wpe/wpe/IWPEService.aidl
@@ -22,6 +22,8 @@ package com.wpe.wpe;
 
 import android.os.Bundle;
 
+import com.wpe.wpe.IWPEServiceHost;
+
 interface IWPEService {
-    int connect(in Bundle args);
+    int connect(in Bundle args, IWPEServiceHost serviceHost);
 }

--- a/wpe/src/main/aidl/com/wpe/wpe/IWPEServiceHost.aidl
+++ b/wpe/src/main/aidl/com/wpe/wpe/IWPEServiceHost.aidl
@@ -17,9 +17,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-package com.wpe.wpe.services;
+package com.wpe.wpe;
 
-public interface WPEServiceConnectionDelegate {
-    void onCleanExit(WPEServiceConnection connection);
-    void onServiceDisconnected(WPEServiceConnection connection);
+interface IWPEServiceHost {
+    void notifyCleanExit();
 }

--- a/wpe/src/main/cpp/Browser/Page.h
+++ b/wpe/src/main/cpp/Browser/Page.h
@@ -91,7 +91,7 @@ private:
     WebKitWebView* m_webView = nullptr;
     struct wpe_android_view_backend_exportable* m_viewBackendExportable = nullptr;
 
-    std::unique_ptr<Renderer> m_renderer;
+    std::shared_ptr<Renderer> m_renderer;
     std::shared_ptr<PageEventObserver> m_observer;
     std::vector<gulong> m_signalHandlers;
     WebKitInputMethodContext* m_input_method_context = nullptr;

--- a/wpe/src/main/cpp/Browser/RendererASurfaceTransaction.h
+++ b/wpe/src/main/cpp/Browser/RendererASurfaceTransaction.h
@@ -29,7 +29,8 @@ struct ASurfaceTransactionStats;
 
 class Page;
 
-class RendererASurfaceTransaction final : public Renderer {
+class RendererASurfaceTransaction final : public Renderer,
+                                          public std::enable_shared_from_this<RendererASurfaceTransaction> {
 public:
     RendererASurfaceTransaction(Page&, unsigned width, unsigned height);
     virtual ~RendererASurfaceTransaction();
@@ -52,10 +53,7 @@ private:
     static void onTransactionCompleteOnAnyThread(void* data, ASurfaceTransactionStats* stats);
 
     Page& m_page;
-    struct {
-        ANativeWindow* window {nullptr};
-        ASurfaceControl* control {nullptr};
-    } m_surface;
+    ASurfaceControl* m_surfaceControl {nullptr};
 
     struct {
         unsigned width;

--- a/wpe/src/main/java/com/wpe/wpe/Browser.java
+++ b/wpe/src/main/java/com/wpe/wpe/Browser.java
@@ -51,7 +51,7 @@ import java.util.Map;
  */
 @UiThread
 public final class Browser {
-    private static final String LOGTAG = "WPE Browser";
+    private static final String LOGTAG = "WPEBrowser";
     // FIXME: There is no real fixed limitation on the number of services an app can spawn on
     //        Android or the number of auxiliary processes WebKit spawns. However we have a
     //        limitation imposed by the way Android requires Services to be defined in the
@@ -106,7 +106,14 @@ public final class Browser {
 
     private WPEServiceConnectionDelegate serviceConnectionDelegate = new WPEServiceConnectionDelegate() {
         @Override
+        public void onCleanExit(WPEServiceConnection connection) {
+            Log.i(LOGTAG, "onCleanExit");
+            auxiliaryProcesses.unregister(connection.getPid());
+        }
+
+        @Override
         public void onServiceDisconnected(WPEServiceConnection connection) {
+            Log.i(LOGTAG, "onServiceDisconnected");
             // Unbinds service which prevents restart on crash.
             // Let wpe restart auxiliary processes if necessary
             auxiliaryProcesses.unregister(connection.getPid());


### PR DESCRIPTION
In general add better handling of clean exits and crashed exits.

This patch includes following features/fixes:

- Added new ipc callback to deal with clean exits before android considers them as crash
- Thread safe callbacks pushed to main thread if needed
- Proper destruction of wpe interface
- SurfaceTransaction fixes to deal with crashed webprocess