### PR TITLE
[wpe] Upgrade to wpewebkit 2.46.3

### DIFF
--- a/tools/scripts/bootstrap.py
+++ b/tools/scripts/bootstrap.py
@@ -81,7 +81,7 @@ from urllib.request import urlretrieve
 
 class Bootstrap:
     default_arch = "arm64"
-    default_version = "2.46.0"
+    default_version = "2.46.3"
 
     _cerbero_origin = "https://github.com/Igalia/wpe-android-cerbero.git"
     _cerbero_branch = "main"

--- a/wpeview/src/main/java/org/wpewebkit/wpe/WKRuntime.java
+++ b/wpeview/src/main/java/org/wpewebkit/wpe/WKRuntime.java
@@ -50,7 +50,7 @@ public final class WKRuntime {
 
     // Bump this version number if you make any changes to the font config
     // or the gstreamer plugins or else they won't be applied.
-    private static final String assetsVersion = "ui_process_assets_2.46.0";
+    private static final String assetsVersion = "ui_process_assets_2.46.3";
 
     static { System.loadLibrary("WPEAndroidRuntime"); }
 


### PR DESCRIPTION
wpewebkit 2.46.3 includes many of the patches that were added on top of 2.46.0 for Android. Those can be now dropped from cerbero build. 2.46.3 also includes renaming from WPEMonitor to WPEScreen which matches better to Android for new platform API.

- [x] Tested on device (Pixel 8)
- [x] Tested on emulator

Note! Before merging this:
- [] https://github.com/Igalia/wpe-android-cerbero/pull/48 must be merged first
- [] https://github.com/Igalia/wpe-android-cerbero/pull/48 must be built and deployed by CI first

Fixes #174 