### PR TITLE
CI: Replace the setup-gradle action with setup-android

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,8 +19,11 @@ jobs:
         with:
           distribution: temurin
           java-version: 17
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+        with:
+          cmdline-tools-version: 11076708
+          log-accepted-android-sdk-licenses: false
       - name: Build Project
         run: ./gradlew assemble${{ inputs.build_type }}
       - name: Save MiniBrowser Artifacts

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,8 +12,11 @@ jobs:
         with:
           distribution: temurin
           java-version: 17
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+        with:
+          cmdline-tools-version: 11076708
+          log-accepted-android-sdk-licenses: false
       - name: Check Code Format
         run: ./gradlew checkFormat
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,10 @@ jobs:
           with:
             distribution: temurin
             java-version: 17
-        - name: Setup Gradle
-          uses: gradle/actions/setup-gradle@v4
+        - name: Setup Android SDK
+          uses: android-actions/setup-android@v3
+          with:
+            cmdline-tools-version: 11076708
+            log-accepted-android-sdk-licenses: false
         - name: Lint checks
           run: ./gradlew lint${{ inputs.build_type }}

--- a/.github/workflows/publish-to-maven-central.yml
+++ b/.github/workflows/publish-to-maven-central.yml
@@ -17,8 +17,11 @@ jobs:
         with:
           distribution: temurin
           java-version: 17
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+        with:
+          cmdline-tools-version: 11076708
+          log-accepted-android-sdk-licenses: false
       - name: Build and publish
         run: ./gradlew wpeview:publishMavenPublicationToMavenCentralRepository
         env:


### PR DESCRIPTION
The setup-android action takes care of making sure that the Android SDK is installed in the desired version, and let the gradlew wrappers fetch Gradle as-needed (which is the recommended anyway). This makes workflows work with [Act][act], allowing running and debugging them locally.

[act]: https://github.com/nektos/act