### PR TITLE
build: Replace deprecated function usages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3
         with:
-          cmdline-tools-version: 11076708
+          cmdline-tools-version: 12266719
           log-accepted-android-sdk-licenses: false
       - name: Build Project
         run: ./gradlew assemble${{ inputs.build_type }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3
         with:
-          cmdline-tools-version: 11076708
+          cmdline-tools-version: 12266719
           log-accepted-android-sdk-licenses: false
       - name: Check Code Format
         run: ./gradlew checkFormat

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,7 @@ jobs:
         - name: Setup Android SDK
           uses: android-actions/setup-android@v3
           with:
-            cmdline-tools-version: 11076708
+            cmdline-tools-version: 12266719
             log-accepted-android-sdk-licenses: false
         - name: Lint checks
           run: ./gradlew lint${{ inputs.build_type }}

--- a/build.gradle
+++ b/build.gradle
@@ -1,16 +1,16 @@
 plugins {
-    id 'com.android.application' version '8.1.2' apply false
-    id 'com.android.library' version '8.1.2' apply false
+    id 'com.android.application' version '8.7.3' apply false
+    id 'com.android.library' version '8.7.3' apply false
     id 'org.jetbrains.kotlin.android' version '1.8.0' apply false
 }
 
 tasks.register("clean", Delete) {
-    delete rootProject.buildDir
+    delete rootProject.layout.buildDirectory
     delete file(".git/hooks/pre-commit")
 }
 
 def installQATools = tasks.register("installQATools", Exec) {
-    def cacheFile = new File(rootProject.buildDir, ".qaToolsInstalled")
+    def cacheFile = rootProject.layout.buildDirectory.file(".qaToolsInstalled").get().asFile
     outputs.file(cacheFile)
     commandLine "python3", "-m", "pip", "install", "--upgrade", "editorconfig-checker", "pycodestyle", "cmakelang"
     doLast {

--- a/tools/mediaplayer/src/main/AndroidManifest.xml
+++ b/tools/mediaplayer/src/main/AndroidManifest.xml
@@ -10,8 +10,7 @@
         <activity
             android:name="org.wpewebkit.tools.mediaplayer.MainActivity"
             android:exported="true"
-            android:launchMode="singleInstance"
-            android:screenOrientation="landscape">
+            android:launchMode="singleInstance">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/tools/mediaplayer/src/main/java/org/wpewebkit/tools/mediaplayer/MainActivity.java
+++ b/tools/mediaplayer/src/main/java/org/wpewebkit/tools/mediaplayer/MainActivity.java
@@ -19,6 +19,7 @@
 
 package org.wpewebkit.tools.mediaplayer;
 
+import android.content.pm.ActivityInfo;
 import android.content.res.AssetManager;
 import android.os.Bundle;
 import android.util.Log;
@@ -53,6 +54,10 @@ public class MainActivity extends AppCompatActivity {
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        // Lock the orientation to landscape
+        setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
+
         setContentView(R.layout.main);
 
         try {

--- a/tools/minibrowser/build.gradle
+++ b/tools/minibrowser/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android' version '1.8.0'
-    id 'androidx.navigation.safeargs' version '2.5.3'
+    id 'androidx.navigation.safeargs' version '2.8.5'
 }
 
 android {
@@ -44,12 +44,12 @@ android {
 
 dependencies {
     implementation project(':wpeview')
-    implementation 'androidx.appcompat:appcompat:1.6.1'
-    implementation 'com.google.android.material:material:1.10.0'
-    implementation 'androidx.core:core-ktx:1.12.0'
-    implementation 'androidx.fragment:fragment-ktx:1.6.1'
-    implementation 'androidx.navigation:navigation-fragment-ktx:2.7.4'
-    implementation 'androidx.navigation:navigation-ui-ktx:2.7.4'
+    implementation 'androidx.appcompat:appcompat:1.7.0'
+    implementation 'com.google.android.material:material:1.12.0'
+    implementation 'androidx.core:core-ktx:1.15.0'
+    implementation 'androidx.fragment:fragment-ktx:1.8.5'
+    implementation 'androidx.navigation:navigation-fragment-ktx:2.8.5'
+    implementation 'androidx.navigation:navigation-ui-ktx:2.8.5'
     implementation 'androidx.preference:preference-ktx:1.2.1'
 
     modules {

--- a/tools/webdriver/build.gradle
+++ b/tools/webdriver/build.gradle
@@ -41,13 +41,13 @@ android {
 
 dependencies {
     implementation project(':wpeview')
-    implementation 'androidx.core:core-ktx:1.9.0'
-    implementation 'androidx.appcompat:appcompat:1.6.1'
-    implementation 'com.google.android.material:material:1.10.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    implementation 'androidx.core:core-ktx:1.15.0'
+    implementation 'androidx.appcompat:appcompat:1.7.0'
+    implementation 'com.google.android.material:material:1.12.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.2.0'
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+    androidTestImplementation 'androidx.test.ext:junit:1.2.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
 
     modules {
         module("org.jetbrains.kotlin:kotlin-stdlib-jdk7") {

--- a/wpeview/build.gradle
+++ b/wpeview/build.gradle
@@ -18,9 +18,6 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
-    lintOptions {
-        disable 'ChromeOsAbiSupport'
-    }
 
     buildTypes {
         release {
@@ -51,24 +48,31 @@ android {
     buildFeatures {
         aidl true
     }
+    lint {
+        disable 'ChromeOsAbiSupport'
+    }
 
-    libraryVariants.all { variant ->
-        def genDir = new File(project.buildDir, "generated/source/services/${variant.name}")
+    libraryVariants.configureEach { variant ->
+        def genDir = project.layout.buildDirectory.dir("generated/source/services/${variant.name}").get().asFile
 
-        def wpeGenServicesTask = tasks.create("wpeGenServices${variant.name.capitalize()}").doLast({
-            def templateFileContent = file("src/main/java/org/wpewebkit/wpe/services/WPEServices.java.template").getText()
-            def services = ""
-            for (int i = 0; i < NUMBER_OF_AUX_PROCESSES; ++i) {
-                services += "    public static final class WebProcessService$i extends WebProcessService {}\n" +
-                    "    public static final class NetworkProcessService$i extends NetworkProcessService {}\n"
+        def wpeGenServicesTask = tasks.register("wpeGenServices${variant.name.capitalize()}") {
+            doLast {
+                def templateFileContent = file("src/main/java/org/wpewebkit/wpe/services/WPEServices.java.template").getText()
+                def services = ""
+                for (int i = 0; i < NUMBER_OF_AUX_PROCESSES; ++i) {
+                    services += "    public static final class WebProcessService$i extends WebProcessService {}\n" +
+                        "    public static final class NetworkProcessService$i extends NetworkProcessService {}\n"
+                }
+                templateFileContent = templateFileContent.replace("    // SERVICES PLACEHOLDER", services)
+
+                def servicesDir = new File(genDir, "org/wpewebkit/wpe/services")
+                servicesDir.mkdirs()
+                new File(servicesDir, "WPEServices.java").write(templateFileContent)
             }
-            templateFileContent = templateFileContent.replace("    // SERVICES PLACEHOLDER", services)
-
-            def servicesDir = new File(genDir, "org/wpewebkit/wpe/services")
-            servicesDir.mkdirs()
-            new File(servicesDir, "WPEServices.java").write(templateFileContent)
-        })
-        wpeGenServicesTask.description = "Generate the code for multiple WPE auxiliary services"
+        }
+        wpeGenServicesTask.configure {
+            description = "Generate the code for multiple WPE auxiliary services"
+        }
         variant.registerJavaGeneratingTask(wpeGenServicesTask, genDir)
 
         variant.outputs.all { output ->
@@ -88,14 +92,14 @@ android {
                 }
                 manifestContent = manifestContent.replace("        <!-- SERVICES PLACEHOLDER -->", services)
                 manifestFile.write(manifestContent)
-                logger.info(manifestContent)
+                project.logger.info(manifestContent)
             })
         }
     }
 }
 
 dependencies {
-    implementation 'androidx.annotation:annotation:1.8.2'
+    implementation 'androidx.annotation:annotation:1.9.1'
     androidTestImplementation "androidx.test:runner:1.6.2"
     androidTestImplementation "androidx.test:rules:1.6.1"
     androidTestImplementation "androidx.test.ext:junit:1.2.1"

--- a/wpeview/src/androidTest/AndroidManifest.xml
+++ b/wpeview/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <application>
+        <activity android:name="org.wpewebkit.wpeview.WPEViewTestActivity"
+            android:label="WPEViewTestActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.FRAMEWORK_INSTRUMENTATION_TEST" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/wpeview/src/main/AndroidManifest.xml
+++ b/wpeview/src/main/AndroidManifest.xml
@@ -4,16 +4,6 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application android:extractNativeLibs="true">
-        <activity android:name="org.wpewebkit.wpeview.WPEViewTestActivity"
-            android:label="WPEViewTestActivity"
-            android:exported="true">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.FRAMEWORK_INSTRUMENTATION_TEST" />
-            </intent-filter>
-        </activity>
-
-
         <!-- Do not remove this section. Service definition is generated at build time -->
         <!-- SERVICES PLACEHOLDER -->
     </application>


### PR DESCRIPTION
Replace deprecated function usages from build.gradle files.

Also includes:
  - Upgrade AGP to more recent version
  - Upgrade library dependencies to more recent versions
  - Upgrade Android cmd line tools version used by CI workflows
  - Add separate AndroidManifest.xml for tests
  - Fix lint errors

#178 
