### PR TITLE
[wpeview] Fix crash on RendererSurfaceControl FD release

### DIFF
--- a/wpeview/src/main/cpp/Runtime/RendererSurfaceControl.cpp
+++ b/wpeview/src/main/cpp/Runtime/RendererSurfaceControl.cpp
@@ -149,7 +149,8 @@ void RendererSurfaceControl::onTransActionAckOnBrowserThread(
             continue;
         }
 
-        resourceIterator->second.m_scopedBuffer->setReleaseFenceFD(surfaceStat.m_fence);
+        if (surfaceStat.m_fence)
+            resourceIterator->second.m_scopedBuffer->setReleaseFenceFD(surfaceStat.m_fence);
         m_releaseBufferQueue.push(std::move(resourceIterator->second.m_scopedBuffer));
     }
     releasedResources.clear();

--- a/wpeview/src/main/cpp/Runtime/ScopedWPEAndroidBuffer.h
+++ b/wpeview/src/main/cpp/Runtime/ScopedWPEAndroidBuffer.h
@@ -56,7 +56,7 @@ public:
     uint32_t width() const noexcept { return m_size.m_width; }
     uint32_t height() const noexcept { return m_size.m_height; }
 
-    int getReleaseFenceFD() const { return m_releaseFenceFD->get(); }
+    int getReleaseFenceFD() const { return m_releaseFenceFD ? m_releaseFenceFD->get() : -1; }
     void setReleaseFenceFD(std::shared_ptr<ScopedFD> releaseFenceFD) { m_releaseFenceFD = std::move(releaseFenceFD); }
 
 private:


### PR DESCRIPTION
It's not guaranteed that RendererSurfaceControl receives previous frame release fd. This patch adds check if fd is valid before trying to use it.

AHardwareBuffer usage and recycling logic is not robust and needs more fixing. But it's better to fix it alongside the adoption of new platform API.

Fixes #137
