### PR TITLE
[wpeview] Use mangled C++ names for entrypoints

### DIFF
--- a/wpeview/src/main/cpp/Service/EntryPoint.cpp
+++ b/wpeview/src/main/cpp/Service/EntryPoint.cpp
@@ -51,8 +51,9 @@ void initializeNativeMain(JNIEnv* /*env*/, jclass /*klass*/, jlong pid, jint typ
     static constexpr const char* const processName[static_cast<int>(ProcessType::TypesCount)]
         = {"WPEWebProcess", "WPENetworkProcess", "WPEWebDriverProcess"};
 
+    // Mangled C++ symbols for WebKit::{Web,Network}ProcessMain(int, char**)
     static constexpr const char* const entrypointName[static_cast<int>(ProcessType::TypesCount)]
-        = {"android_WebProcess_main", "android_NetworkProcess_main", "android_WebDriverProcess_main"};
+        = {"_ZN6WebKit14WebProcessMainEiPPc", "_ZN6WebKit18NetworkProcessMainEiPPc", "android_WebDriverProcess_main"};
 
     using ProcessEntryPoint = int(int, char**);
     auto* entrypoint


### PR DESCRIPTION
Use the C++ mangled named for the `WebKit::WebProcessMain()` and `WebKit::NetworkProcessMain()` functions, instead of the ones with the `android_` prefix.

This will allow dropping a patch on top of vanilla WPE WebKit that added the `android_WebProcess_main()` and `android_NetworkProcess_main()` symbols. The only additional thing those wrappers did was sending the list of arguments to the Android log, for debugging purposes, but that may be re-added at a later time inside `initializeNativeMain()` without needing to modify WPE WebKit.