### PR TITLE
lint: Treat new package version checks as warnings

### DIFF
--- a/tools/mediaplayer/lint.xml
+++ b/tools/mediaplayer/lint.xml
@@ -4,4 +4,8 @@
     <issue id="LogConditional" severity="ignore" />
     <issue id="InvalidPackage" severity="ignore" />
     <issue id="MonochromeLauncherIcon" severity="ignore" />
+
+    <issue id="AndroidGradlePluginVersion" severity="warning" />
+    <issue id="NewerVersionAvailable" severity="warning" />
+    <issue id="GradleDependency" severity="warning" />
 </lint>

--- a/wpeview/lint.xml
+++ b/wpeview/lint.xml
@@ -5,4 +5,8 @@
     </issue>
     <issue id="LogConditional" severity="ignore" />
     <issue id="ChromeOsAbiSupport" severity="ignore" />
+
+    <issue id="AndroidGradlePluginVersion" severity="warning" />
+    <issue id="NewerVersionAvailable" severity="warning" />
+    <issue id="GradleDependency" severity="warning" />
 </lint>


### PR DESCRIPTION
Change the severity of the `AndroidGradlePluginVersion`, `NewerVersionAvailable`, and `GradleDependency` lint checks to warnings, to avoid detection of newer versions from stopping the CI.