### PR TITLE
webdriver: Add missing urllib3 dependency

### DIFF
--- a/tools/scripts/webkitpy/requirements.txt
+++ b/tools/scripts/webkitpy/requirements.txt
@@ -5,3 +5,4 @@ pytest_timeout==2.1.0
 pytest_asyncio==0.18.3
 requests==2.24
 websockets==8.1
+urllib3==2.3


### PR DESCRIPTION
Add the missing `urllib3` dependency to the list of requirements needed to run Selenium and W3C tests. This should fix errors like the following:

  https://github.com/Igalia/wpe-android/actions/runs/14041836539/job/39334480607#step:9:16