### PR TITLE
[minibrowser] Apply system bar insets to main view

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ kotlin = "2.1.0"
 vanniktech = "0.30.0"
 androidx-navigation-safeargs = "2.8.5"
 
+androidx-activity = "1.10.1"
 androidx-annotation = "1.9.1"
 androidx-test-runner = "1.6.2"
 androidx-test-rules = "1.6.1"
@@ -36,6 +37,7 @@ vanniktech-maven-publish = { id = "com.vanniktech.maven.publish", version.ref = 
 androidx-navigation-safeargs = { id = "androidx.navigation.safeargs", version.ref = "androidx-navigation-safeargs" }
 
 [libraries]
+androidx-activity = { group = "androidx.activity", name = "activity", version.ref = "androidx-activity" }
 androidx-annotation = { group = "androidx.annotation", name = "annotation", version.ref = "androidx-annotation" }
 androidx-test-runner = { group = "androidx.test", name = "runner", version.ref = "androidx-test-runner" }
 androidx-test-rules = { group = "androidx.test", name = "rules", version.ref = "androidx-test-rules" }

--- a/tools/minibrowser/src/main/java/org/wpewebkit/tools/minibrowser/BrowserFragment.kt
+++ b/tools/minibrowser/src/main/java/org/wpewebkit/tools/minibrowser/BrowserFragment.kt
@@ -27,6 +27,9 @@ import android.view.*
 import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputMethodManager
 import android.widget.FrameLayout
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
@@ -96,6 +99,12 @@ class BrowserFragment : Fragment(R.layout.fragment_browser) {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         Log.i(TAG, "onViewCreated")
         super.onViewCreated(view, savedInstanceState)
+
+        ViewCompat.setOnApplyWindowInsetsListener(binding.main) { v, insets ->
+            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.updatePadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
+            WindowInsetsCompat.CONSUMED
+        }
 
         val currentState = browserViewModel.browserState.value
         currentState.selectedTabId?.let { selectedTabId ->

--- a/tools/minibrowser/src/main/java/org/wpewebkit/tools/minibrowser/MainActivity.kt
+++ b/tools/minibrowser/src/main/java/org/wpewebkit/tools/minibrowser/MainActivity.kt
@@ -26,6 +26,7 @@ package org.wpewebkit.tools.minibrowser
 import android.content.res.Configuration
 import android.os.Bundle
 import android.util.Log
+import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.navigation.fragment.NavHostFragment
 import org.wpewebkit.tools.minibrowser.databinding.ActivityMainBinding
@@ -44,6 +45,7 @@ class MainActivity : AppCompatActivity(R.layout.activity_main) {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         Log.d(TAG, "onCreate")
+        enableEdgeToEdge();
         binding = ActivityMainBinding.inflate(layoutInflater)
     }
 


### PR DESCRIPTION
Add an insets listener to apply the system bar insets to the browser main view, ensuring that the main view will not cover the bars. While at it, opt-in to edge-to-edge mode explicitly to ensure the same behaviour also on older Android releases.

In Android 15 applications targeting SDK 35 are opted in to edge-to-edge mode, which makes applications cover as much of the screen as possible but may result in undesired overlaps if unhandled. For now the handling is as simple as possible to get the existing behaviour back.

Fixes #189