### PR TITLE
[wpe] Upgrade to WPE WebKit 2.46.7

### DIFF
--- a/tools/scripts/bootstrap.py
+++ b/tools/scripts/bootstrap.py
@@ -81,7 +81,7 @@ from urllib.request import urlretrieve
 
 class Bootstrap:
     default_arch = "arm64"
-    default_version = "2.46.3"
+    default_version = "2.46.7"
 
     _cerbero_origin = "https://github.com/Igalia/wpe-android-cerbero.git"
     _cerbero_branch = "main"

--- a/wpeview/src/main/java/org/wpewebkit/wpe/WKRuntime.java
+++ b/wpeview/src/main/java/org/wpewebkit/wpe/WKRuntime.java
@@ -50,7 +50,7 @@ public final class WKRuntime {
 
     // Bump this version number if you make any changes to the font config
     // or the gstreamer plugins or else they won't be applied.
-    private static final String assetsVersion = "ui_process_assets_2.46.3";
+    private static final String assetsVersion = "ui_process_assets_2.46.7";
 
     static { System.loadLibrary("WPEAndroidRuntime"); }
 


### PR DESCRIPTION
This will be the last update in the series before moving over to the 2.48.x ones.

The corresponding Cerbero update was done in https://github.com/Igalia/wpe-android-cerbero/pull/56