### PR TITLE
[minibrowser] Take into account IME insets

### DIFF
--- a/tools/minibrowser/src/main/java/org/wpewebkit/tools/minibrowser/BrowserFragment.kt
+++ b/tools/minibrowser/src/main/java/org/wpewebkit/tools/minibrowser/BrowserFragment.kt
@@ -102,7 +102,12 @@ class BrowserFragment : Fragment(R.layout.fragment_browser) {
 
         ViewCompat.setOnApplyWindowInsetsListener(binding.main) { v, insets ->
             val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
-            v.updatePadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
+            val padding = if (insets.isVisible(WindowInsetsCompat.Type.ime())) {
+                androidx.core.graphics.Insets.max(systemBars, insets.getInsets(WindowInsetsCompat.Type.ime()))
+            } else {
+                systemBars
+            }
+            v.updatePadding(padding.left, padding.top, padding.right, padding.bottom)
             WindowInsetsCompat.CONSUMED
         }
 


### PR DESCRIPTION
Check whether IME is visible (i.e. the on screen keyboard) and take it into account when applying insets to the main browser fragment. Previously only the system bars insets were taken into account, which resulted in the IME covering the toolbar and part of the web view.

Fixes #192