### PR TITLE
[wpe] Update to WPE WebKit 2.48.2

### DIFF
--- a/tools/scripts/bootstrap.py
+++ b/tools/scripts/bootstrap.py
@@ -81,7 +81,7 @@ from urllib.request import urlretrieve
 
 class Bootstrap:
     default_arch = "arm64"
-    default_version = "2.46.7"
+    default_version = "2.48.2"
 
     _cerbero_origin = "https://github.com/Igalia/wpe-android-cerbero.git"
     _cerbero_branch = "main"
@@ -275,7 +275,7 @@ class Bootstrap:
 
         runtime_file_path = os.path.join(self._project_build_dir,
                                          self._runtime_package_name_template.format(arch=self._arch, version=version))
-        subprocess.check_call(["tar", "xf", runtime_file_path, "-C", self._sysroot_dir, "lib"])
+        subprocess.check_call(["tar", "xf", runtime_file_path, "-C", self._sysroot_dir, "lib", "share"])
 
     def _copy_headers(self, target_dir):
         shutil.rmtree(target_dir, True)
@@ -347,7 +347,7 @@ class Bootstrap:
         shutil.rmtree(target_dir, True)
         os.makedirs(target_dir)
         sysroot_inspector_resources_file = os.path.join(
-            self._sysroot_dir, "lib", "wpe-webkit-2.0", "libWPEWebInspectorResources.so")
+            self._sysroot_dir, "share", "wpe-webkit-2.0", "inspector.gresource")
         shutil.copy(sysroot_inspector_resources_file, target_dir)
         sysroot_injected_bundle_file = os.path.join(
             self._sysroot_dir, "lib", "wpe-webkit-2.0", "injected-bundle", "libWPEInjectedBundle.so")

--- a/wpeview/src/main/java/org/wpewebkit/wpe/WKRuntime.java
+++ b/wpeview/src/main/java/org/wpewebkit/wpe/WKRuntime.java
@@ -50,7 +50,7 @@ public final class WKRuntime {
 
     // Bump this version number if you make any changes to the font config
     // or the gstreamer plugins or else they won't be applied.
-    private static final String assetsVersion = "ui_process_assets_2.46.7";
+    private static final String assetsVersion = "ui_process_assets_2.48.2";
 
     static { System.loadLibrary("WPEAndroidRuntime"); }
 
@@ -95,6 +95,9 @@ public final class WKRuntime {
             envStrings.add("GIO_EXTRA_MODULES");
             envStrings.add(new File(context.getFilesDir(), "gio").getAbsolutePath());
             envStrings.add("WEBKIT_INJECTED_BUNDLE_PATH");
+            envStrings.add(new File(context.getFilesDir(), "injected-bundles").getAbsolutePath());
+            // TODO: Move elsewhere than the injected bundle path.
+            envStrings.add("WEBKIT_INSPECTOR_RESOURCES_PATH");
             envStrings.add(new File(context.getFilesDir(), "injected-bundles").getAbsolutePath());
 
             String filesPath = context.getFilesDir().getAbsolutePath();

--- a/wpeview/src/main/java/org/wpewebkit/wpe/services/NetworkProcessService.java
+++ b/wpeview/src/main/java/org/wpewebkit/wpe/services/NetworkProcessService.java
@@ -36,7 +36,7 @@ public class NetworkProcessService extends WPEService {
 
     // Bump this version number if you make any changes to the gio
     // modules or else they won't be applied.
-    private static final String assetsVersion = "network_process_assets_gst1.24.7";
+    private static final String assetsVersion = "network_process_assets_2.48.2_gst_1.24.8";
 
     @Override
     protected void loadNativeLibraries() {

--- a/wpeview/src/main/java/org/wpewebkit/wpe/services/WebDriverProcessService.java
+++ b/wpeview/src/main/java/org/wpewebkit/wpe/services/WebDriverProcessService.java
@@ -16,7 +16,7 @@ public class WebDriverProcessService extends WPEService {
 
     // Bump this version number if you make any changes to the gio
     // modules or else they won't be applied.
-    private static final String assetsVersion = "webdriver_process_assets_gst1.24.7";
+    private static final String assetsVersion = "webdriver_process_assets_2.48.2_gst_1.24.8";
 
     @Override
     protected void loadNativeLibraries() {

--- a/wpeview/src/main/java/org/wpewebkit/wpe/services/WebProcessService.java
+++ b/wpeview/src/main/java/org/wpewebkit/wpe/services/WebProcessService.java
@@ -44,7 +44,7 @@ public class WebProcessService extends WPEService {
 
     // Bump this version number if you make any changes to the font config
     // or the gstreamer plugins or else they won't be applied.
-    private static final String assetsVersion = "web_process_assets_gst1.24.7";
+    private static final String assetsVersion = "web_process_assets_2.48.2_gst_1.24.8";
 
     @Override
     protected void loadNativeLibraries() {
@@ -121,6 +121,9 @@ public class WebProcessService extends WPEService {
         envStrings.add("XDG_DATA_HOME");
         envStrings.add(filesPath);
         envStrings.add("WEBKIT_INJECTED_BUNDLE_PATH");
+        envStrings.add(new File(context.getFilesDir(), "injected-bundles").getAbsolutePath());
+        // TODO: Move elsewhere than the injected bundle path.
+        envStrings.add("WEBKIT_INSPECTOR_RESOURCES_PATH");
         envStrings.add(new File(context.getFilesDir(), "injected-bundles").getAbsolutePath());
 
         if ((appInfo.flags & ApplicationInfo.FLAG_DEBUGGABLE) == ApplicationInfo.FLAG_DEBUGGABLE) {


### PR DESCRIPTION
Web Inspector resources now being shipped as a `.gresource` file instead of a shared library, which needed changes in the bootstrap script and setting the relevant environment variable. For now the `.gresource` file is installed along the injected bundle, as the shared library was previously, but this may change in the future.

----

~~Note this is expected to fail CI until bootstrap packages for the corresponding release are available.~~ Bootstrap packages for 2.48.2 are now available 😄 