### PR TITLE
Improve bootstrap's script handling of dependencies and related documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,22 @@ To see WPEView in action check the [tools](tools) folder.
 
 ## Setting up your environment
 
-### python3
+A "bootstrap" Python script is available to **fetch** or **build** the dependencies needed by wpe-android.
 
-The bootstrap script requires [python3](https://www.python.org/downloads/).
+Besides [python3](https://www.python.org/downloads/), additional dependencies are required:
+
+### Dependencies needed for fetching
+
+ * `readelf` is needed to identify wpe-android direct or indirect dependencies
+ * `tar` is needed to unpack downloaded dependencies
+
+### Dependencies needed for building
+
+ * `git` is needed to check out Cerbero
+ * `python3-distro` and `python3-venv` are needed by Cerbero
+ * `ruby` and `unifdef` are required to  build WPE WebKit
+
+## Using the bootstrap script
 
 ### Getting the dependencies
 
@@ -61,6 +74,8 @@ To ease the cross-compilation process we use
 ```
 
 This command will fetch the required binaries and place them in the expected location.
+
+### Building the dependencies
 
 If you want to build (and/or modify) the dependencies you can pass the `--build` option:
 
@@ -84,7 +99,9 @@ For example, device debug build dependencies can be generated using
 ```bash
 ./tools/scripts/bootstrap.py --build --debug --arch=arm64
 ```
-### Android Project
+
+## Android Project
+
 Once the bootstrap process is done and all the dependencies are cross-compiled and installed,
 you should be able to generate android project from gradle files.
 ```bash
@@ -143,7 +160,7 @@ pip install selenium
 
 ### 2. Create python Selenium script
 
-Save following as simple_test.py
+Save the following as `simple_test.py`
 
 ```bash
 from selenium import webdriver
@@ -161,6 +178,7 @@ driver = webdriver.Remote(command_executor="http://127.0.0.1:8888", options=opti
 driver.get('http://www.wpewebkit.org')
 driver.quit()
 ```
+
 ### 3. Run webdriver application on emulator
 
 From android studio run webdriver application on x86-64 emulator.

--- a/tools/scripts/bootstrap.py
+++ b/tools/scripts/bootstrap.py
@@ -402,6 +402,12 @@ class Bootstrap:
                 shutil.copyfile(lib_path, os.path.join(target_dir, filename), follow_symlinks=False)
 
     def _resolve_deps(self, system_lib_dir, plugins_dir_list):
+        """This method identifies the two categories of WPE WebKit dependencies.
+
+        - "NEEDED but not provided" refers to libraries not built by Cerbero since Android already provides them.
+        - "Provided but not NEEDED" refers to libraries not listed in libWPEWebKit.so's ELF header, but packaged anyway,
+        as they are typically dlopen'd at runtime.
+        """
         soname_set = set()
         needed_set = set(self._base_needed)
 

--- a/tools/scripts/bootstrap.py
+++ b/tools/scripts/bootstrap.py
@@ -484,7 +484,19 @@ class Bootstrap:
             self._create_android_wrapper_script(os.path.join(
                 self._project_root_dir, "tools", "minibrowser", "src", "main", "resources", "lib", android_abi))
 
+    def ensure_script_deps(self):
+        script_deps = ["readelf", "tar"]
+        if self._build:
+            script_deps += ["git"]
+        missing_deps = [dep for dep in script_deps if not shutil.which(dep)]
+        if len(missing_deps) > 0:
+            raise Exception("Unsatisfied dependencies: this script needs {0} to run".format(", ".join(missing_deps)))
+
     def run(self):
+        try:
+            self.ensure_script_deps()
+        except Exception as e:
+            sys.exit(e)
         version = self.default_version
         if self._external_cerbero_build_path:
             version = self.copy_all_packages_from_external_cerbero_build()

--- a/tools/scripts/bootstrap.py
+++ b/tools/scripts/bootstrap.py
@@ -241,7 +241,10 @@ class Bootstrap:
             subprocess.check_call(["git", "clone", "--branch", self._cerbero_branch,
                                   self._cerbero_origin, "cerbero"], cwd=self._project_build_dir)
 
-        subprocess.check_call(self._cerbero_command_args + ["bootstrap"])
+        try:
+            subprocess.check_call(self._cerbero_command_args + ["bootstrap"])
+        except subprocess.CalledProcessError as e:
+            sys.exit(e)
         if self._debug:
             self._patch_wpewebkit_recipe_for_debug_build()
 
@@ -252,8 +255,11 @@ class Bootstrap:
         print("Building dependencies with Cerbero...")
 
         os.makedirs(self._project_build_dir, exist_ok=True)
-        subprocess.check_call(self._cerbero_command_args +
-                              ["package", "-o", self._project_build_dir, "-f", "wpewebkit"])
+        try:
+            subprocess.check_call(self._cerbero_command_args +
+                                  ["package", "-o", self._project_build_dir, "-f", "wpewebkit"])
+        except subprocess.CalledProcessError as e:
+            sys.exit(e)
         return self._get_package_version("wpewebkit")
 
     def extract_deps(self, version):


### PR DESCRIPTION
The dependencies needed to run `bootstrap.py` are not listed in README, and are only apparent after running the script.

This PR addresses that by making them explicit, bailing out earlier if not available. 

Additionally, by handling subprocess errors with `try - except`, subsequent errors raised by Cerbero are also easier to spot (and address).

I noticed part of this had been raised as an issue in #172 , so this PR closes it.