### PR TITLE
[wpe] Update entry point name for WebDriverProcess

### DIFF
--- a/wpeview/src/main/cpp/Service/EntryPoint.cpp
+++ b/wpeview/src/main/cpp/Service/EntryPoint.cpp
@@ -53,7 +53,8 @@ void initializeNativeMain(JNIEnv* /*env*/, jclass /*klass*/, jlong pid, jint typ
 
     // Mangled C++ symbols for WebKit::{Web,Network}ProcessMain(int, char**)
     static constexpr const char* const entrypointName[static_cast<int>(ProcessType::TypesCount)]
-        = {"_ZN6WebKit14WebProcessMainEiPPc", "_ZN6WebKit18NetworkProcessMainEiPPc", "android_WebDriverProcess_main"};
+        = {"_ZN6WebKit14WebProcessMainEiPPc", "_ZN6WebKit18NetworkProcessMainEiPPc",
+            "_ZN6WebKit20WebDriverProcessMainEiPPc"};
 
     using ProcessEntryPoint = int(int, char**);
     auto* entrypoint


### PR DESCRIPTION
https://github.com/Igalia/wpe-android/blob/b918e3f8b86eda406436cb251c2e7b10a529008c/wpeview/src/main/cpp/Service/EntryPoint.cpp#L55 describes the expected mangled names for the various entry points.

After https://commits.webkit.org/293601@main, the entry point was intended to change into `WebKit::WebDriverProcessMain` (but it didn't because it was using an undeclared namespace)

This PR needs a corresponding WebKit upstream one that I'll link shortly