### PR TITLE
[minibrowser] Set custom preferences theme layout for dark mode

### DIFF
--- a/tools/minibrowser/src/main/res/values-night/themes.xml
+++ b/tools/minibrowser/src/main/res/values-night/themes.xml
@@ -2,5 +2,10 @@
 <resources>
     <!-- Base application theme. -->
     <style name="Theme.MiniBrowser" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <item name="preferenceTheme">@style/PrefsTheme</item>
+    </style>
+
+    <style name="PrefsTheme" parent="@style/PreferenceThemeOverlay.v14.Material">
+        <item name="android:layout">@layout/fragment_settings</item>
     </style>
 </resources>


### PR DESCRIPTION
Dark mode was missing custom layout for preferences and thus it crashes. This patch adds custom preferences theme and layout for dark mode theme.

Fixes #198 