### PR TITLE
[minibrowser] Apply standard insets to settings views

### DIFF
--- a/tools/minibrowser/src/main/java/org/wpewebkit/tools/minibrowser/BrowserFragment.kt
+++ b/tools/minibrowser/src/main/java/org/wpewebkit/tools/minibrowser/BrowserFragment.kt
@@ -27,14 +27,12 @@ import android.view.*
 import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputMethodManager
 import android.widget.FrameLayout
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.updatePadding
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
 import org.wpewebkit.tools.minibrowser.R
 import org.wpewebkit.tools.minibrowser.databinding.FragmentBrowserBinding
+import org.wpewebkit.tools.minibrowser.requestApplyStandardInsets
 import org.wpewebkit.wpeview.WPEChromeClient
 import org.wpewebkit.wpeview.WPEView
 import org.wpewebkit.wpeview.WPEViewClient
@@ -99,17 +97,7 @@ class BrowserFragment : Fragment(R.layout.fragment_browser) {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         Log.i(TAG, "onViewCreated")
         super.onViewCreated(view, savedInstanceState)
-
-        ViewCompat.setOnApplyWindowInsetsListener(binding.main) { v, insets ->
-            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
-            val padding = if (insets.isVisible(WindowInsetsCompat.Type.ime())) {
-                androidx.core.graphics.Insets.max(systemBars, insets.getInsets(WindowInsetsCompat.Type.ime()))
-            } else {
-                systemBars
-            }
-            v.updatePadding(padding.left, padding.top, padding.right, padding.bottom)
-            WindowInsetsCompat.CONSUMED
-        }
+        view.requestApplyStandardInsets()
 
         val currentState = browserViewModel.browserState.value
         currentState.selectedTabId?.let { selectedTabId ->

--- a/tools/minibrowser/src/main/java/org/wpewebkit/tools/minibrowser/Utils.kt
+++ b/tools/minibrowser/src/main/java/org/wpewebkit/tools/minibrowser/Utils.kt
@@ -1,6 +1,38 @@
 package org.wpewebkit.tools.minibrowser
 
+import android.view.View
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
 import java.net.URI
+
+fun View.requestApplyInsetsWhenAttached() {
+    if (isAttachedToWindow) {
+        requestApplyInsets()
+    } else {
+        addOnAttachStateChangeListener(object : View.OnAttachStateChangeListener {
+            override fun onViewAttachedToWindow(v: View) {
+                v.removeOnAttachStateChangeListener(this)
+                v.requestApplyInsets()
+            }
+            override fun onViewDetachedFromWindow(v: View) = Unit
+        })
+    }
+}
+
+fun View.requestApplyStandardInsets() {
+    ViewCompat.setOnApplyWindowInsetsListener(this) { view, insets ->
+        val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+        val padding = if (insets.isVisible(WindowInsetsCompat.Type.ime())) {
+            androidx.core.graphics.Insets.max(systemBars, insets.getInsets(WindowInsetsCompat.Type.ime()))
+        } else {
+            systemBars
+        }
+        view.updatePadding(padding.left, padding.top, padding.right, padding.bottom)
+        WindowInsetsCompat.CONSUMED
+    }
+    requestApplyInsetsWhenAttached()
+}
 
 object Utils {
     private fun addressHasWebScheme(address: String) : Boolean {

--- a/tools/minibrowser/src/main/java/org/wpewebkit/tools/minibrowser/settings/SettingsFragment.kt
+++ b/tools/minibrowser/src/main/java/org/wpewebkit/tools/minibrowser/settings/SettingsFragment.kt
@@ -29,6 +29,7 @@ import androidx.navigation.fragment.findNavController
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import org.wpewebkit.tools.minibrowser.R
+import org.wpewebkit.tools.minibrowser.requestApplyStandardInsets
 
 class SettingsFragment : PreferenceFragmentCompat() {
     private val TAG = "SettingsFragment"
@@ -43,6 +44,8 @@ class SettingsFragment : PreferenceFragmentCompat() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        view.requestApplyStandardInsets()
+
         val toolbar = view.findViewById<Toolbar>(R.id.settingsToolbar)
         toolbar.apply {
             title = getString(R.string.action_settings)

--- a/tools/minibrowser/src/main/java/org/wpewebkit/tools/minibrowser/settings/clearbrowsingdata/ClearBrowsingDataFragment.kt
+++ b/tools/minibrowser/src/main/java/org/wpewebkit/tools/minibrowser/settings/clearbrowsingdata/ClearBrowsingDataFragment.kt
@@ -33,6 +33,7 @@ import com.google.android.material.snackbar.Snackbar
 import org.wpewebkit.tools.minibrowser.BrowserViewModel
 import org.wpewebkit.tools.minibrowser.R
 import org.wpewebkit.tools.minibrowser.databinding.FragmentClearBrowsingDataBinding
+import org.wpewebkit.tools.minibrowser.requestApplyStandardInsets
 import kotlinx.coroutines.Dispatchers.Main
 import kotlinx.coroutines.launch
 
@@ -44,6 +45,7 @@ class ClearBrowsingDataFragment : Fragment(R.layout.fragment_clear_browsing_data
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        view.requestApplyStandardInsets()
 
         binding = FragmentClearBrowsingDataBinding.bind(view)
 


### PR DESCRIPTION
Apply “standard” insets (IME + system toolbars) to the Minibrowser settings views. While at it, factor out the code into a `View` extension method which gets reused by all the views that needs to have insets applied.

Also, make sure that the insets are applied even if a `View` is not yet attached. This is achieved by installing an `OnAttachStateChangeListener` when the View is not yet attached, which then requests application and removes itself afterwards.

----

Fixes #199