### PR TITLE
[wpe] Remove unnecessary onInputMethodContextOut() call

### DIFF
--- a/wpeview/src/main/java/org/wpewebkit/wpe/WKWebView.java
+++ b/wpeview/src/main/java/org/wpewebkit/wpe/WKWebView.java
@@ -460,7 +460,6 @@ public final class WKWebView {
         case WKWebView.LOAD_STARTED:
             if (wpeViewClient != null)
                 wpeViewClient.onPageStarted(wpeView, uri);
-            onInputMethodContextOut();
             break;
         case WKWebView.LOAD_FINISHED:
             if (wpeViewClient != null)


### PR DESCRIPTION
There is a call onInputMethodContextOut() to hide IME when page loading starts. This is a workaround because WebKit didn't properly handle IME in this case. However, it has been fixed in WebKit by https://bugs.webkit.org/show_bug.cgi?id=273387. Thus this call can be removed.