### PR TITLE
Prepare for wpe-android-cerbero update

### DIFF
--- a/tools/scripts/bootstrap.py
+++ b/tools/scripts/bootstrap.py
@@ -100,7 +100,7 @@ class Bootstrap:
         "libgobject-2.0.so",
         "libwpe-1.0.so",
         "libWPEBackend-android.so",
-        "libWPEWebKit-2.0_1.so"
+        "libWPEWebKit-2.0.so"
     ]
     _build_includes = [
         ("glib-2.0", "glib-2.0"),
@@ -112,9 +112,8 @@ class Bootstrap:
     ]
     _soname_replacements = [
         ("libnettle.so.8", "libnettle_8.so"),  # This entry is not retrievable from the packaged libnettle.so
-        ("libWPEWebKit-2.0.so.1", "libWPEWebKit-2.0_1.so")  # This is for libWPEInjectedBundle.so
     ]
-    _base_needed = ["libWPEWebKit-2.0_1.so"]
+    _base_needed = ["libWPEWebKit-2.0.so"]
 
     def __init__(self, args=None):
         args = args or {}

--- a/wpeview/src/main/cpp/CMakeLists.txt
+++ b/wpeview/src/main/cpp/CMakeLists.txt
@@ -72,7 +72,7 @@ set_target_properties(soup-3.0 PROPERTIES IMPORTED_LOCATION
 add_library(WPEWebKit-2.0 SHARED IMPORTED)
 set_target_properties(
     WPEWebKit-2.0
-    PROPERTIES IMPORTED_LOCATION "${CMAKE_SOURCE_DIR}/imported/lib/${ANDROID_ABI}/libWPEWebKit-2.0_1.so"
+    PROPERTIES IMPORTED_LOCATION "${CMAKE_SOURCE_DIR}/imported/lib/${ANDROID_ABI}/libWPEWebKit-2.0.so"
                INTERFACE_INCLUDE_DIRECTORIES
                "${CMAKE_SOURCE_DIR}/imported/include/wpe-webkit;${CMAKE_SOURCE_DIR}/imported/include/libsoup-3.0")
 


### PR DESCRIPTION
As wpe-android-cerbero is updated to 1.26.3, libWPEWebKit no longer needs soname patching.

This depends on https://github.com/Igalia/wpe-android-cerbero/pull/70