### PR TITLE
[wpeview] Make WKRuntime log the WPE WebKit version

### DIFF
--- a/wpeview/src/main/cpp/Runtime/WKRuntime.cpp
+++ b/wpeview/src/main/cpp/Runtime/WKRuntime.cpp
@@ -145,6 +145,12 @@ void wpeTerminateProcess(void* /*backend*/, int64_t pid)
 }
 } // namespace
 
+WKRuntime::WKRuntime()
+{
+    Logging::logDebug("WKRuntime [tid %d], WPE WebKit %u.%u.%u", gettid(), webkit_get_major_version(),
+        webkit_get_minor_version(), webkit_get_micro_version());
+}
+
 void WKRuntime::configureJNIMappings()
 {
     getJNIBrowserCache();

--- a/wpeview/src/main/cpp/Runtime/WKRuntime.h
+++ b/wpeview/src/main/cpp/Runtime/WKRuntime.h
@@ -44,7 +44,7 @@ public:
     void invokeOnUiThread(void (*onExec)(void*), void (*onDestroy)(void*), void* userData) const noexcept;
 
 private:
-    WKRuntime() = default;
+    WKRuntime();
 
     friend class JNIBrowserCache;
     void jniInit();


### PR DESCRIPTION
Log the version of WPE WebKit currently in use when WKRuntime is instantiated. This is useful for debugging, specially when shuffling and testing different versions.