### PR TITLE
WKRuntime: Use ParcelFileDescriptor.fromFd

### DIFF
--- a/wpeview/src/main/java/org/wpewebkit/wpe/WKRuntime.java
+++ b/wpeview/src/main/java/org/wpewebkit/wpe/WKRuntime.java
@@ -177,7 +177,7 @@ public final class WKRuntime {
         try {
             Class<?> serviceClass =
                 Class.forName("org.wpewebkit.wpe.services.WPEServices$" + processType.name() + "Service" + processSlot);
-            ParcelFileDescriptor parcelFd = ParcelFileDescriptor.adoptFd(fd);
+            ParcelFileDescriptor parcelFd = ParcelFileDescriptor.fromFd(fd);
 
             Log.v(LOGTAG, "Launching service: " + processType.name());
             Intent intent = new Intent(applicationContext, serviceClass);


### PR DESCRIPTION
WebKit's ProcessLauncher::launchProcess, in ProcessLauncherGLib.cpp, keeps full ownership of the socket pair's client file descript as it shares it into LibWPE's launchProcess.

wpe-android assumed transferred ownership, and used ParcelFileDescriptor.adoptFd for the incoming file descriptor, which resulting in fdsan aborting when the WebKit side closed.

This changes it to use ParcelFileDescriptor.fromFd, which in turn duplicates the descriptor.

As a workaround for this fdsan problem, we used a patch in wpe-android-cerbero that reverted using RAII file descriptors in WebKit, something that effectively resulted in the fd being transferred over. Landing this in wpe-android requires removing the patch in wpe-android-cerbero.