### PR TITLE
Expose WPE WebKit and GStreamer versions to Java

### DIFF
--- a/tools/scripts/bootstrap.py
+++ b/tools/scripts/bootstrap.py
@@ -104,6 +104,7 @@ class Bootstrap:
     ]
     _build_includes = [
         ("glib-2.0", "glib-2.0"),
+        ("gstreamer-1.0", "gstreamer-1.0"),
         ("libsoup-3.0", "libsoup-3.0"),
         ("wpe-1.0", "wpe"),
         ("wpe-android", "wpe-android"),

--- a/wpeview/src/main/cpp/CMakeLists.txt
+++ b/wpeview/src/main/cpp/CMakeLists.txt
@@ -65,6 +65,11 @@ add_library(gmodule-2.0 SHARED IMPORTED)
 set_target_properties(gmodule-2.0 PROPERTIES IMPORTED_LOCATION
                                              "${CMAKE_SOURCE_DIR}/imported/lib/${ANDROID_ABI}/libgmodule-2.0.so")
 
+add_library(gstreamer-1.0 SHARED IMPORTED)
+set_target_properties(
+    gstreamer-1.0 PROPERTIES IMPORTED_LOCATION "${CMAKE_SOURCE_DIR}/imported/lib/${ANDROID_ABI}/libgstreamer-1.0.so"
+                             INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_SOURCE_DIR}/imported/include/gstreamer-1.0")
+
 add_library(soup-3.0 SHARED IMPORTED)
 set_target_properties(soup-3.0 PROPERTIES IMPORTED_LOCATION
                                           "${CMAKE_SOURCE_DIR}/imported/lib/${ANDROID_ABI}/libsoup-3.0.so")
@@ -95,11 +100,20 @@ set_target_properties(WPEWebDriver PROPERTIES IMPORTED_LOCATION
 # ######################################################################################################################
 
 # libWPEAndroidCommon
-add_library(WPEAndroidCommon SHARED Common/Environment.cpp Common/Logging.cpp Common/JNI/JNIClass.cpp
+add_library(WPEAndroidCommon SHARED Common/Environment.cpp Common/Init.cpp Common/Logging.cpp Common/JNI/JNIClass.cpp
                                     Common/JNI/JNIEnv.cpp Common/JNI/JNIString.cpp)
 target_configure_quality(WPEAndroidCommon)
 target_include_directories(WPEAndroidCommon INTERFACE Common)
-target_link_libraries(WPEAndroidCommon ${android-lib} ${log-lib} ${sync-lib})
+target_link_libraries(
+    WPEAndroidCommon
+    ${android-lib}
+    ${log-lib}
+    ${sync-lib}
+    glib-2.0
+    gobject-2.0
+    gstreamer-1.0
+    libwpe-1.0
+    WPEWebKit-2.0)
 
 # libWPEAndroidRuntime
 add_library(

--- a/wpeview/src/main/cpp/Common/Init.cpp
+++ b/wpeview/src/main/cpp/Common/Init.cpp
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) 2025 Igalia S.L. <info@igalia.com>
+ *   Author: Adrian Perez de Castro <aperez@igalia.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include "Init.h"
+#include "Logging.h"
+#include <gst/gst.h>
+#include <wpe/webkit.h>
+
+static void initializeWKVersions()
+{
+    auto klass = JNI::Class("org/wpewebkit/wpe/WKVersions");
+    g_autofree char* webkitVersion = g_strdup_printf(
+        "%u.%u.%u", webkit_get_major_version(), webkit_get_minor_version(), webkit_get_micro_version());
+
+    klass.getStaticField<jstring>("WEBKIT").setValue(JNI::String(webkitVersion));
+    klass.getStaticField<jint>("WEBKIT_MAJOR").setValue(webkit_get_major_version());
+    klass.getStaticField<jint>("WEBKIT_MINOR").setValue(webkit_get_minor_version());
+    klass.getStaticField<jint>("WEBKIT_MICRO").setValue(webkit_get_micro_version());
+
+    g_autofree char* gstVersion = gst_version_string();
+    unsigned gstMajor, gstMinor, gstMicro, gstNano;
+    gst_version(&gstMajor, &gstMinor, &gstMicro, &gstNano);
+
+    klass.getStaticField<jstring>("GSTREAMER").setValue(JNI::String(gstVersion));
+    klass.getStaticField<jint>("GSTREAMER_MAJOR").setValue(gstMajor);
+    klass.getStaticField<jint>("GSTREAMER_MINOR").setValue(gstMinor);
+    klass.getStaticField<jint>("GSTREAMER_MICRO").setValue(gstMicro);
+    klass.getStaticField<jint>("GSTREAMER_NANO").setValue(gstNano);
+
+    Logging::logVerbose("WKRuntime::Init: WPE WebKit %s, GStreamer %s", webkitVersion, gstVersion);
+}
+
+JNIEnv* Init::initialize(JavaVM* javaVM)
+{
+    auto* env = JNI::initVM(javaVM);
+    initializeWKVersions();
+    return env;
+}

--- a/wpeview/src/main/cpp/Common/Init.h
+++ b/wpeview/src/main/cpp/Common/Init.h
@@ -1,0 +1,28 @@
+/**
+ * Copyright (C) 2025 Igalia S.L. <info@igalia.com>
+ *   Author: Adrian Perez de Castro <aperez@igalia.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#pragma once
+
+#include "JNI/JNI.h"
+
+namespace Init {
+
+JNIEnv* initialize(JavaVM*);
+
+} // namespace Init

--- a/wpeview/src/main/cpp/Runtime/EntryPoint.cpp
+++ b/wpeview/src/main/cpp/Runtime/EntryPoint.cpp
@@ -17,6 +17,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include "Init.h"
 #include "WKCallback.h"
 #include "WKCookieManager.h"
 #include "WKNetworkSession.h"
@@ -29,7 +30,7 @@
 extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* javaVM, void* /*reserved*/)
 {
     try {
-        JNI::initVM(javaVM);
+        Init::initialize(javaVM);
 
         WKRuntime::configureJNIMappings();
         WKCallback::configureJNIMappings();

--- a/wpeview/src/main/cpp/Service/EntryPoint.cpp
+++ b/wpeview/src/main/cpp/Service/EntryPoint.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "Environment.h"
+#include "Init.h"
 #include "Logging.h"
 
 #include <cassert>
@@ -98,7 +99,7 @@ void initializeNativeMain(JNIEnv* /*env*/, jclass /*klass*/, jlong pid, jint typ
 extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* javaVM, void* /*reserved*/)
 {
     try {
-        JNI::initVM(javaVM);
+        Init::initialize(javaVM);
 
         JNI::Class("org/wpewebkit/wpe/services/WPEService")
             .registerNativeMethods(

--- a/wpeview/src/main/java/org/wpewebkit/wpe/WKRuntime.java
+++ b/wpeview/src/main/java/org/wpewebkit/wpe/WKRuntime.java
@@ -48,10 +48,6 @@ import java.util.List;
 public final class WKRuntime {
     private static final String LOGTAG = "WKRuntime";
 
-    // Bump this version number if you make any changes to the font config
-    // or the gstreamer plugins or else they won't be applied.
-    private static final String assetsVersion = "ui_process_assets_2.48.6";
-
     static { System.loadLibrary("WPEAndroidRuntime"); }
 
     protected static native void startNativeLooper();
@@ -66,7 +62,7 @@ public final class WKRuntime {
 
     public static @NonNull WKRuntime getInstance() { return singleton; }
 
-    private WKRuntime() { Log.v(LOGTAG, "WPE WKRuntime creation"); }
+    private WKRuntime() { Log.v(LOGTAG, "WKRuntime creation"); }
 
     private Context applicationContext = null;
 
@@ -83,6 +79,7 @@ public final class WKRuntime {
         if (applicationContext == null) {
             applicationContext = context.getApplicationContext();
 
+            final String assetsVersion = WKVersions.versionedAssets("ui_process");
             if (ServiceUtils.needAssets(applicationContext, assetsVersion)) {
                 ServiceUtils.copyFileOrDir(applicationContext, applicationContext.getAssets(), "injected-bundles",
                                            true);

--- a/wpeview/src/main/java/org/wpewebkit/wpe/WKVersions.java
+++ b/wpeview/src/main/java/org/wpewebkit/wpe/WKVersions.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2025 Igalia S.L. <info@igalia.com>
+ *   Author: Adrian Perez de Castro <aperez@igalia.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package org.wpewebkit.wpe;
+
+import androidx.annotation.NonNull;
+
+public class WKVersions {
+    public static int WEBKIT_MAJOR = 0;
+    public static int WEBKIT_MINOR = 0;
+    public static int WEBKIT_MICRO = 0;
+    public static @NonNull String WEBKIT = "";
+
+    public static int GSTREAMER_MAJOR = 0;
+    public static int GSTREAMER_MINOR = 0;
+    public static int GSTREAMER_MICRO = 0;
+    public static int GSTREAMER_NANO = 0;
+    public static @NonNull String GSTREAMER = "";
+
+    public static @NonNull String versionedAssets(@NonNull String componentName) {
+        return componentName + "_" + WEBKIT + "_gst_" + GSTREAMER;
+    }
+}

--- a/wpeview/src/main/java/org/wpewebkit/wpe/services/NetworkProcessService.java
+++ b/wpeview/src/main/java/org/wpewebkit/wpe/services/NetworkProcessService.java
@@ -28,15 +28,12 @@ import android.util.Log;
 import androidx.annotation.NonNull;
 
 import org.wpewebkit.wpe.WKProcessType;
+import org.wpewebkit.wpe.WKVersions;
 
 import java.io.File;
 
 public class NetworkProcessService extends WPEService {
     private static final String LOGTAG = "WPENetworkProcess";
-
-    // Bump this version number if you make any changes to the gio
-    // modules or else they won't be applied.
-    private static final String assetsVersion = "network_process_assets_2.48.6_gst_1.24.8";
 
     @Override
     protected void loadNativeLibraries() {
@@ -53,6 +50,7 @@ public class NetworkProcessService extends WPEService {
 
     @Override
     protected void setupServiceEnvironment() {
+        final String assetsVersion = WKVersions.versionedAssets("network_process");
         Context context = getApplicationContext();
         if (ServiceUtils.needAssets(context, assetsVersion)) {
             ServiceUtils.copyFileOrDir(context, getAssets(), "gio", true);

--- a/wpeview/src/main/java/org/wpewebkit/wpe/services/WebDriverProcessService.java
+++ b/wpeview/src/main/java/org/wpewebkit/wpe/services/WebDriverProcessService.java
@@ -7,16 +7,13 @@ import android.util.Log;
 import androidx.annotation.NonNull;
 
 import org.wpewebkit.wpe.WKProcessType;
+import org.wpewebkit.wpe.WKVersions;
 
 import java.io.File;
 
 public class WebDriverProcessService extends WPEService {
 
     private static final String LOGTAG = "WPEWebDriverProcess";
-
-    // Bump this version number if you make any changes to the gio
-    // modules or else they won't be applied.
-    private static final String assetsVersion = "webdriver_process_assets_2.48.6_gst_1.24.8";
 
     @Override
     protected void loadNativeLibraries() {
@@ -33,6 +30,7 @@ public class WebDriverProcessService extends WPEService {
     }
     @Override
     protected void setupServiceEnvironment() {
+        final String assetsVersion = WKVersions.versionedAssets("webdriver_process");
         Context context = getApplicationContext();
         if (ServiceUtils.needAssets(context, assetsVersion)) {
             ServiceUtils.copyFileOrDir(context, getAssets(), "gio", true);

--- a/wpeview/src/main/java/org/wpewebkit/wpe/services/WebProcessService.java
+++ b/wpeview/src/main/java/org/wpewebkit/wpe/services/WebProcessService.java
@@ -32,6 +32,7 @@ import androidx.annotation.NonNull;
 
 import org.freedesktop.gstreamer.GStreamer;
 import org.wpewebkit.wpe.WKProcessType;
+import org.wpewebkit.wpe.WKVersions;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -41,10 +42,6 @@ import java.util.Properties;
 
 public class WebProcessService extends WPEService {
     private static final String LOGTAG = "WPEWebProcess";
-
-    // Bump this version number if you make any changes to the font config
-    // or the gstreamer plugins or else they won't be applied.
-    private static final String assetsVersion = "web_process_assets_2.48.6_gst_1.24.8";
 
     @Override
     protected void loadNativeLibraries() {
@@ -62,6 +59,7 @@ public class WebProcessService extends WPEService {
 
     @Override
     protected void setupServiceEnvironment() {
+        final String assetsVersion = WKVersions.versionedAssets("web_process");
         Context context = getApplicationContext();
         if (ServiceUtils.needAssets(context, assetsVersion)) {
             ServiceUtils.copyFileOrDir(context, getAssets(), "gstreamer-1.0", true);


### PR DESCRIPTION
This adds a new `WKVersions` Java class which contains static constants for the WPE WebKit and GStreamer versions being used at run time. The values are filled early during the `JNI_OnLoad` implementation, in common code used both by the runtime (UI) and service (helper processes) entry points, which allows using the values from any of the other Java classes.

The first usage of the new functionality is calculating at runtime the versioned strings used to identify unpacked assets for each of the processes. This avoids the need to manually update those, which is easy to forget.

In the future this could also be used for other purposes, e.g. the MiniBrowser could show the versions in its settings activity for error reporting and debugging purposes.