### PR TITLE
[wpeview] Track the current Java VM and Activity instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ override fun onCreate(savedInstanceState: Bundle?) {
 }
 ```
 
+Note that applications that want to subclass `android.app.Application`
+*must* use `org.wpewebkit.WPEApplication` as their base class instead.
+
 To see WPEView in action check the [tools](tools) folder.
 
 ## Setting up your environment

--- a/wpeview/src/main/AndroidManifest.xml
+++ b/wpeview/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
 
-    <application android:extractNativeLibs="true">
+    <application android:name=".WPEApplication" android:extractNativeLibs="true">
         <!-- Do not remove this section. Service definition is generated at build time -->
         <!-- SERVICES PLACEHOLDER -->
     </application>

--- a/wpeview/src/main/cpp/Common/JNI/JNIEnv.cpp
+++ b/wpeview/src/main/cpp/Common/JNI/JNIEnv.cpp
@@ -32,6 +32,11 @@ pthread_key_t globalJNIEnvKey = 0;
 std::atomic_bool globalEnableJavaExceptionDescription = true;
 // NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)
 
+extern "C" __attribute__((visibility("default"))) JavaVM* wpe_android_runtime_get_current_java_vm()
+{
+    return globalJavaVM;
+}
+
 void detachTerminatedNativeThread(void* /*keyValue*/)
 {
     if (globalJavaVM != nullptr)

--- a/wpeview/src/main/cpp/Runtime/EntryPoint.cpp
+++ b/wpeview/src/main/cpp/Runtime/EntryPoint.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "Init.h"
+#include "Logging.h"
 #include "WKCallback.h"
 #include "WKCookieManager.h"
 #include "WKNetworkSession.h"
@@ -42,7 +43,8 @@ extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* javaVM, void* /*reserved*/)
         WKSettings::configureJNIMappings();
 
         return JNI::VERSION;
-    } catch (...) {
+    } catch (const std::exception& e) {
+        Logging::logError("Runtime: JNI_OnLoad: %s", e.what());
         return JNI_ERR;
     }
 }

--- a/wpeview/src/main/cpp/Service/EntryPoint.cpp
+++ b/wpeview/src/main/cpp/Service/EntryPoint.cpp
@@ -107,7 +107,8 @@ extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* javaVM, void* /*reserved*/)
                 JNI::StaticNativeMethod<void(jlong, jint, jint)>("initializeNativeMain", initializeNativeMain));
 
         return JNI::VERSION;
-    } catch (...) {
+    } catch (const std::exception& e) {
+        Logging::logError("Service: JNI_OnLoad: %s", e.what());
         return JNI_ERR;
     }
 }

--- a/wpeview/src/main/java/org/wpewebkit/WPEApplication.java
+++ b/wpeview/src/main/java/org/wpewebkit/WPEApplication.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (C) 2025 Igalia S.L. <info@igalia.com>
+ *   Author: Adrian Perez de Castro <aperez@igalia.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package org.wpewebkit;
+
+import android.app.Activity;
+import android.app.Application;
+import android.os.Bundle;
+import android.util.Log;
+
+public class WPEApplication extends Application {
+    static final String LOGTAG = "WPEApplication";
+
+    private enum ProcessKind {
+        MAIN {
+            @Override
+            public String[] getLibraryNames() {
+                return new String[] {"WPEAndroidRuntime"};
+            }
+        },
+        NETWORK {
+            @Override
+            public String[] getLibraryNames() {
+                return new String[] {"WPEAndroidService"};
+            }
+        },
+        WEBCONTENT {
+            @Override
+            public String[] getLibraryNames() {
+                return new String[] {"gstreamer-1.0", "WPEAndroidService"};
+            }
+        },
+        WEBDRIVER {
+            @Override
+            public String[] getLibraryNames() {
+                return new String[] {"WPEWebDriver", "WPEAndroidService"};
+            }
+        };
+
+        abstract public String[] getLibraryNames();
+    }
+
+    private static final ProcessKind getProcessKind() {
+        String name = getProcessName();
+        int colonPosition = name.indexOf(':');
+        if (colonPosition < 0)
+            return ProcessKind.MAIN;
+
+        name = name.substring(colonPosition + 1).replaceAll("[0-9]", "");
+        switch (name) {
+        case "WPEWebProcess":
+            return ProcessKind.WEBCONTENT;
+        case "WPENetworkProcess":
+            return ProcessKind.NETWORK;
+        case "WPEWebDriverProcess":
+            return ProcessKind.WEBDRIVER;
+        default:
+            throw new IllegalStateException("Cannot derive process kind from '" + getProcessName() + "'");
+        }
+    }
+
+    public static final ProcessKind processKind = getProcessKind();
+
+    static {
+        final String libraries[] = processKind.getLibraryNames();
+        Log.d(LOGTAG, "Process: " + processKind.toString() + " - Libraries: " + String.join(", ", libraries));
+        for (String libraryName : libraries)
+            System.loadLibrary(libraryName);
+    }
+
+    public WPEApplication() {
+        super();
+        if (processKind == ProcessKind.MAIN)
+            registerActivityLifecycleCallbacks(new org.wpewebkit.wpe.WKActivityObserver());
+    }
+}

--- a/wpeview/src/main/java/org/wpewebkit/wpe/WKActivityObserver.java
+++ b/wpeview/src/main/java/org/wpewebkit/wpe/WKActivityObserver.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (C) 2025 Igalia S.L. <info@igalia.com>
+ *   Author: Adrian Perez de Castro <aperez@igalia.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package org.wpewebkit.wpe;
+
+import android.app.Activity;
+import android.app.Application;
+import android.os.Bundle;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+
+public class WKActivityObserver implements Application.ActivityLifecycleCallbacks {
+    private static final String LOGTAG = "WKActivityObserver";
+
+    @Override
+    public void onActivityCreated(@NonNull Activity a, @NonNull Bundle b) {
+        Log.d(LOGTAG, "activity created: " + a);
+    }
+
+    @Override
+    public void onActivityStarted(@NonNull Activity a) {
+        Log.d(LOGTAG, "activity started: " + a);
+        handleActivityStarted(a);
+    }
+
+    @Override
+    public void onActivityPaused(@NonNull Activity a) {
+        Log.d(LOGTAG, "activity paused: " + a);
+    }
+
+    @Override
+    public void onActivityResumed(@NonNull Activity a) {
+        Log.d(LOGTAG, "activity resumed: " + a);
+    }
+
+    @Override
+    public void onActivityStopped(@NonNull Activity a) {
+        Log.d(LOGTAG, "activity stopped: " + a);
+        handleActivityStopped(a);
+    }
+
+    @Override
+    public void onActivityDestroyed(@NonNull Activity a) {
+        Log.d(LOGTAG, "activity destroyed: " + a);
+    }
+
+    @Override
+    public void onActivitySaveInstanceState(@NonNull Activity a, @NonNull Bundle b) {
+        Log.d(LOGTAG, "activity save state: " + a);
+    }
+
+    private static native void handleActivityStarted(@NonNull Activity a);
+    private static native void handleActivityStopped(@NonNull Activity a);
+}

--- a/wpeview/src/main/java/org/wpewebkit/wpe/WKRuntime.java
+++ b/wpeview/src/main/java/org/wpewebkit/wpe/WKRuntime.java
@@ -48,8 +48,6 @@ import java.util.List;
 public final class WKRuntime {
     private static final String LOGTAG = "WKRuntime";
 
-    static { System.loadLibrary("WPEAndroidRuntime"); }
-
     protected static native void startNativeLooper();
     private static native void setupNativeEnvironment(@NonNull String[] envStringsArray);
     private native void nativeInit();

--- a/wpeview/src/main/java/org/wpewebkit/wpe/services/NetworkProcessService.java
+++ b/wpeview/src/main/java/org/wpewebkit/wpe/services/NetworkProcessService.java
@@ -36,7 +36,7 @@ public class NetworkProcessService extends WPEService {
     private static final String LOGTAG = "WPENetworkProcess";
 
     @Override
-    protected void loadNativeLibraries() {
+    protected void setupServiceEnvironment() {
         // To debug the sub-process with Android Studio (Java and native code), you must:
         // 1- Uncomment the following instruction to wait for the debugger before loading native code.
         // 2- Force the dual debugger (Java + Native) in Run/Debug configuration (the automatic detection won't work).
@@ -45,11 +45,6 @@ public class NetworkProcessService extends WPEService {
 
         // android.os.Debug.waitForDebugger();
 
-        System.loadLibrary("WPEAndroidService");
-    }
-
-    @Override
-    protected void setupServiceEnvironment() {
         final String assetsVersion = WKVersions.versionedAssets("network_process");
         Context context = getApplicationContext();
         if (ServiceUtils.needAssets(context, assetsVersion)) {

--- a/wpeview/src/main/java/org/wpewebkit/wpe/services/WPEService.java
+++ b/wpeview/src/main/java/org/wpewebkit/wpe/services/WPEService.java
@@ -75,7 +75,6 @@ public abstract class WPEService extends Service {
     protected static native void setupNativeEnvironment(@NonNull String[] envStringsArray);
     protected static native void initializeNativeMain(long pid, int processType, int fd);
 
-    protected abstract void loadNativeLibraries();
     protected abstract void setupServiceEnvironment();
     protected abstract void initializeServiceMain(long pid, @NonNull ParcelFileDescriptor parcelFd);
 
@@ -83,7 +82,6 @@ public abstract class WPEService extends Service {
     public void onCreate() {
         Log.d(LOGTAG, "onCreate()");
         super.onCreate();
-        loadNativeLibraries();
         setupServiceEnvironment();
     }
 

--- a/wpeview/src/main/java/org/wpewebkit/wpe/services/WebDriverProcessService.java
+++ b/wpeview/src/main/java/org/wpewebkit/wpe/services/WebDriverProcessService.java
@@ -16,7 +16,7 @@ public class WebDriverProcessService extends WPEService {
     private static final String LOGTAG = "WPEWebDriverProcess";
 
     @Override
-    protected void loadNativeLibraries() {
+    protected void setupServiceEnvironment() {
         // To debug the sub-process with Android Studio (Java and native code), you must:
         // 1- Uncomment the following instruction to wait for the debugger before loading native code.
         // 2- Force the dual debugger (Java + Native) in Run/Debug configuration (the automatic detection won't work).
@@ -25,11 +25,6 @@ public class WebDriverProcessService extends WPEService {
 
         // android.os.Debug.waitForDebugger();
 
-        System.loadLibrary("WPEWebDriver");
-        System.loadLibrary("WPEAndroidService");
-    }
-    @Override
-    protected void setupServiceEnvironment() {
         final String assetsVersion = WKVersions.versionedAssets("webdriver_process");
         Context context = getApplicationContext();
         if (ServiceUtils.needAssets(context, assetsVersion)) {

--- a/wpeview/src/main/java/org/wpewebkit/wpe/services/WebProcessService.java
+++ b/wpeview/src/main/java/org/wpewebkit/wpe/services/WebProcessService.java
@@ -44,7 +44,7 @@ public class WebProcessService extends WPEService {
     private static final String LOGTAG = "WPEWebProcess";
 
     @Override
-    protected void loadNativeLibraries() {
+    protected void setupServiceEnvironment() {
         // To debug the sub-process with Android Studio (Java and native code), you must:
         // 1- Uncomment the following instruction to wait for the debugger before loading native code.
         // 2- Force the dual debugger (Java + Native) in Run/Debug configuration (the automatic detection won't work).
@@ -53,12 +53,6 @@ public class WebProcessService extends WPEService {
 
         // android.os.Debug.waitForDebugger();
 
-        System.loadLibrary("gstreamer-1.0");
-        System.loadLibrary("WPEAndroidService");
-    }
-
-    @Override
-    protected void setupServiceEnvironment() {
         final String assetsVersion = WKVersions.versionedAssets("web_process");
         Context context = getApplicationContext();
         if (ServiceUtils.needAssets(context, assetsVersion)) {


### PR DESCRIPTION
Add `WPEApplication`, a subclass of `android.app.Application` which registers a `WKActivityObserver` to track activity lifecycle. For now the observer only tracks the last started `android.app.Activity` and forwards it to its native `handleActivity{Started,Stopped}()` methods.

The current VM instance and `Activity` are exposed to native code through the following functions, which have C linkage and are publicly exposed by `libWPEAndroidCommon`:

```c
  JavaVM* wpe_android_runtime_get_current_java_vm()
  jobject wpe_android_runtime_get_current_activity()
```

The intention is that WebKit will use `dlsym()` to resolve those, thus avoiding a circular dependency at build time.

Due to `WPEApplication` being instantiated much earlier than other classes with native methods, it must take care itself of issuing the needed `System.loadLibrary()` calls. Moreover, application services also get to use the same application class declared in the manifest, which means `WPEApplication` must now handle loading the native libraries needed by services as well. Fortunately, the static `Application.getProcessName()` method may be used to determine in which kind of process we are, and act accordingly.

----

This is used by https://github.com/WebKit/WebKit/pull/50857