### PR TITLE
[wpe] Update to WPE WebKit 2.50.0

### DIFF
--- a/tools/scripts/bootstrap.py
+++ b/tools/scripts/bootstrap.py
@@ -81,7 +81,7 @@ from urllib.request import urlretrieve
 
 class Bootstrap:
     default_arch = "arm64"
-    default_version = "2.48.6"
+    default_version = "2.50.0"
 
     _cerbero_origin = "https://github.com/Igalia/wpe-android-cerbero.git"
     _cerbero_branch = "main"


### PR DESCRIPTION
Even when this is an update to a new release series, there are no differences from the packaging point of view, so the version number change is enough.

----

This will need new bootstrap packages to be uploaded after https://github.com/Igalia/wpe-android-cerbero/pull/80 is merged before the CI can pass.