### PR TITLE
Fixes for AndroidStudio

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,11 +43,11 @@ def installGitHook = tasks.register("installGitHook") {
     }
 }
 
-gradle.afterProject { project ->
-    project.tasks.all { task ->
+allprojects {
+    tasks.configureEach { task ->
         def lowerName = task.name.toLowerCase()
         if ((task.group != "help") &&
-            (lowerName.indexOf("clean") < 0) &&
+            !lowerName.contains("clean") &&
             (lowerName != "wrapper") &&
             (lowerName != "installqatools") &&
             (lowerName != "installgithook")) {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/wpeview/build.gradle
+++ b/wpeview/build.gradle
@@ -42,6 +42,23 @@ android {
             path file("src/main/cpp/CMakeLists.txt")
         }
     }
+
+    def abiList = []
+    for (abi in ["x86_64", "arm64-v8a"]) {
+        if (file("src/main/jniLibs/$abi").isDirectory())
+            abiList.add(abi)
+    }
+
+    if (abiList.isEmpty()) {
+        logger.warn("Cannot find ABI dependencies. Please call ./tools/scripts/bootstrap.py before build")
+    } else {
+        logger.info("Detected ABI: $abiList")
+        defaultConfig {
+            ndk {
+                abiFilters.addAll(abiList)
+            }
+        }
+    }
 }
 
 dependencies {
@@ -90,21 +107,3 @@ mavenPublishing {
     signAllPublications()
 }
 
-gradle.afterProject { project ->
-    if (project == getProject()) {
-        def abiList = []
-        for (abi in ["x86_64", "arm64-v8a"]) {
-            if (file("src/main/jniLibs/$abi").isDirectory())
-                abiList.add(abi)
-        }
-        project.android.defaultConfig.ndk.abiFilters = abiList
-
-        if (abiList.isEmpty()) {
-            println("Cannot find ABI dependencies")
-            println("Please call ./tools/scripts/bootstrap.py before build")
-        } else {
-            println("Detected ABI: $abiList")
-            println("Use ./tools/scripts/bootstrap.py to install dependencies for more ABIs")
-        }
-    }
-}


### PR DESCRIPTION
When trying to build MiniBrowser with Android studio a java.lang.NoSuchMethodError was generated. Apparently it was caused by a binary incompatibility between Gradle 9.3.1 and AGP 8.8.0. AGP 9.0 removed several APIs that AGP depends on, meaning that it basically breaks compatibility with AGP < 9.

AGP >= 9.0 is not strictly required so it seems a good idea to downgrade the version in order to have proper builds in the most popular IDE for Android development.

Apart from that, and while not strictly needed, we're migrating gradle.afterProject to a more modern approach of doing things. Modifying the ABI filters inside afterProject is considered a legacy approach that could lead to race conditions in the build (or rather the Sync phase). By moving the logic into the android block we ensure that AndroidStudio can see the configuration during the sync phase.