### PR TITLE
Add the required changes to use the OpenXR loader

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,8 @@ androidx-navigation-fragment-ktx = "2.8.5"
 androidx-navigation-ui-ktx = "2.8.5"
 androidx-preference-ktx = "1.2.1"
 
+openxrLoader = "1.1.48"
+
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
@@ -52,3 +54,4 @@ androidx-fragment-ktx = { group = "androidx.fragment", name = "fragment-ktx", ve
 androidx-navigation-fragment-ktx = { group = "androidx.navigation", name = "navigation-fragment-ktx", version.ref = "androidx-navigation-fragment-ktx" }
 androidx-navigation-ui-ktx = { group = "androidx.navigation", name = "navigation-ui-ktx", version.ref = "androidx-navigation-ui-ktx" }
 androidx-preference-ktx = { group = "androidx.preference", name = "preference-ktx", version.ref = "androidx-preference-ktx" }
+openxr-loader = { module = "org.khronos.openxr:openxr_loader_for_android", version.ref = "openxrLoader" }

--- a/tools/minibrowser/build.gradle
+++ b/tools/minibrowser/build.gradle
@@ -25,6 +25,7 @@ android {
 
     buildFeatures {
         viewBinding = true
+        prefab true
     }
 
     java {
@@ -57,6 +58,7 @@ dependencies {
     implementation libs.androidx.navigation.fragment.ktx
     implementation libs.androidx.navigation.ui.ktx
     implementation libs.androidx.preference.ktx
+    runtimeOnly libs.openxr.loader
 
     modules {
         module("org.jetbrains.kotlin:kotlin-stdlib-jdk7") {

--- a/tools/minibrowser/src/main/AndroidManifest.xml
+++ b/tools/minibrowser/src/main/AndroidManifest.xml
@@ -9,6 +9,19 @@
         android:required="false" />
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="org.khronos.openxr.permission.OPENXR_SYSTEM" />
+
+    <queries>
+      <provider android:authorities="org.khronos.openxr.runtime_broker;org.khronos.openxr.system_runtime_broker" />
+
+      <intent>
+        <action android:name="org.khronos.openxr.OpenXRRuntimeService" />
+      </intent>
+
+      <intent>
+        <action android:name="org.khronos.openxr.OpenXRApiLayerService" />
+      </intent>
+    </queries>
 
     <application
         android:banner="@drawable/banner"
@@ -18,6 +31,7 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.MiniBrowser"
         android:usesCleartextTraffic="true">
+        <uses-native-library android:name="libopenxr_loader.so" android:required="false" />
         <activity
             android:name="org.wpewebkit.tools.minibrowser.MainActivity"
             android:exported="true"

--- a/tools/scripts/bootstrap.py
+++ b/tools/scripts/bootstrap.py
@@ -100,7 +100,8 @@ class Bootstrap:
         "libgobject-2.0.so",
         "libwpe-1.0.so",
         "libWPEBackend-android.so",
-        "libWPEWebKit-2.0.so"
+        "libWPEWebKit-2.0.so",
+        "libopenxr_loader.so"
     ]
     _build_includes = [
         ("glib-2.0", "glib-2.0"),


### PR DESCRIPTION
There were several definitions in the manifest that were missing that are required for Android apps to be able to load the OpenXR loader.

Apart from that we need to declare the runtime dependency in the gradle files. The minimum required version for the loader was bumped because that's the first version that includes a fix for LOAD segments aligned to 16kb boundaries (that would be a requirement soon for Android apps).