### PR TITLE
Convenience API: Add new high-level API for Android

### DIFF
--- a/wpeview/src/main/java/org/wpewebkit/wpe/WPEEventType.java
+++ b/wpeview/src/main/java/org/wpewebkit/wpe/WPEEventType.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package org.wpewebkit.wpe;
+
+/**
+ * Mirror of the {@code WPEEventType} enum from WebKit's {@code WPEEvent.h}.
+ * Values must be kept in sync with the C header.
+ */
+public final class WPEEventType {
+    private WPEEventType() {}
+
+    public static final int NONE = 0;
+    public static final int POINTER_DOWN = 1;
+    public static final int POINTER_UP = 2;
+    public static final int POINTER_MOVE = 3;
+    public static final int POINTER_ENTER = 4;
+    public static final int POINTER_LEAVE = 5;
+    public static final int SCROLL = 6;
+    public static final int KEYBOARD_KEY_DOWN = 7;
+    public static final int KEYBOARD_KEY_UP = 8;
+    public static final int TOUCH_DOWN = 9;
+    public static final int TOUCH_UP = 10;
+    public static final int TOUCH_MOVE = 11;
+    public static final int TOUCH_CANCEL = 12;
+}

--- a/wpeview/src/main/java/org/wpewebkit/wpeview/CookieManager.java
+++ b/wpeview/src/main/java/org/wpewebkit/wpeview/CookieManager.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package org.wpewebkit.wpeview;
+
+import android.annotation.SuppressLint;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import org.wpewebkit.wpe.WebKitCookieManager;
+import org.wpewebkit.wpe.WebKitWebsiteDataManager;
+
+import java.util.EnumSet;
+
+/**
+ * CookieManager handles the cookie policy and storage for a specific {@link WebContext}.
+ */
+public final class CookieManager {
+    private static final CookieAcceptPolicy DEFAULT_POLICY = CookieAcceptPolicy.AcceptNoThirdParty;
+
+    public enum CookieAcceptPolicy {
+        AcceptAlways(0),
+        AcceptNever(1),
+        AcceptNoThirdParty(2);
+
+        private final int value;
+
+        CookieAcceptPolicy(int value) { this.value = value; }
+
+        int getValue() { return value; }
+    }
+
+    private final WebKitCookieManager cookieManager;
+    private final WebKitWebsiteDataManager websiteDataManager;
+    private CookieAcceptPolicy currentPolicy = DEFAULT_POLICY;
+
+    CookieManager(@NonNull WebKitCookieManager cookieManager, @NonNull WebKitWebsiteDataManager websiteDataManager) {
+        this.cookieManager = cookieManager;
+        this.websiteDataManager = websiteDataManager;
+    }
+
+    public void getCookieAcceptPolicy(@Nullable WPECallback<CookieAcceptPolicy> callback) {
+        cookieManager.getAcceptPolicy(policy -> {
+            currentPolicy = CookieAcceptPolicy.values()[policy];
+            if (callback != null)
+                callback.onResult(currentPolicy);
+        });
+    }
+
+    public void setCookieAcceptPolicy(@NonNull CookieAcceptPolicy policy) {
+        currentPolicy = policy;
+        cookieManager.setAcceptPolicy(policy.getValue());
+    }
+
+    public void setAcceptCookie(boolean accept) {
+        setCookieAcceptPolicy(accept ? CookieAcceptPolicy.AcceptAlways : CookieAcceptPolicy.AcceptNever);
+    }
+
+    @SuppressLint("KotlinPropertyAccess")
+    public boolean acceptCookie() {
+        return currentPolicy != CookieAcceptPolicy.AcceptNever;
+    }
+
+    public void removeAllCookies(@Nullable WPECallback<Boolean> callback) {
+        websiteDataManager.clear(EnumSet.of(WebKitWebsiteDataManager.WebsiteDataType.Cookies),
+                                 callback != null ? callback::onResult : null);
+    }
+}

--- a/wpeview/src/main/java/org/wpewebkit/wpeview/WebChromeClient.java
+++ b/wpeview/src/main/java/org/wpewebkit/wpeview/WebChromeClient.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package org.wpewebkit.wpeview;
+
+import android.view.View;
+
+import androidx.annotation.NonNull;
+
+/**
+ * WebChromeClient provides the high-level chrome and UI callbacks for {@link WebView}.
+ */
+public class WebChromeClient {
+    public void onCloseWindow(@NonNull WebView window) {}
+    public void onProgressChanged(@NonNull WebView view, int newProgress) {}
+    public void onReceivedTitle(@NonNull WebView view, @NonNull String title) {}
+
+    public interface CustomViewCallback {
+        void onCustomViewHidden();
+    }
+
+    // FIXME: wire WebKit enter-fullscreen / leave-fullscreen signals to invoke these callbacks.
+    public void onShowCustomView(@NonNull View view, @NonNull CustomViewCallback callback) {}
+    public void onHideCustomView() {}
+}

--- a/wpeview/src/main/java/org/wpewebkit/wpeview/WebContext.java
+++ b/wpeview/src/main/java/org/wpewebkit/wpeview/WebContext.java
@@ -1,0 +1,130 @@
+/**
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package org.wpewebkit.wpeview;
+
+import android.util.DisplayMetrics;
+
+import androidx.annotation.NonNull;
+
+import org.wpewebkit.wpe.WKRuntime;
+import org.wpewebkit.wpe.WPEDisplay;
+import org.wpewebkit.wpe.WPEScreen;
+import org.wpewebkit.wpe.WebKitCookieManager;
+import org.wpewebkit.wpe.WebKitNetworkSession;
+import org.wpewebkit.wpe.WebKitSettings;
+import org.wpewebkit.wpe.WebKitWebContext;
+import org.wpewebkit.wpe.WebKitWebsiteDataManager;
+
+/**
+ * WebContext represents the shared engine and session state used by high-level {@link WebView} instances.
+ * It manages the lifecycle of the display, web context, network session, cookies, and settings wrappers.
+ */
+public class WebContext {
+    private final WPEDisplay display;
+    private final WPEScreen screen;
+    private final WebKitWebContext webContext;
+    private final WebKitNetworkSession networkSession;
+    private final WebKitCookieManager webKitCookieManager;
+    private final WebKitWebsiteDataManager websiteDataManager;
+    private final WebKitSettings settings;
+    private final android.content.Context appContext;
+    private CookieManager cookieManager;
+
+    public WebContext(@NonNull android.content.Context context) { this(context, false); }
+
+    public WebContext(@NonNull android.content.Context context, boolean automationMode) {
+        this(context, automationMode, shouldUseEphemeralSession());
+    }
+
+    public WebContext(@NonNull android.content.Context context, boolean automationMode, boolean ephemeralSession) {
+        this.appContext = context.getApplicationContext();
+        WKRuntime.getInstance().initialize(appContext);
+
+        this.display = new WPEDisplay();
+        this.screen = display.getScreen();
+        DisplayMetrics displayMetrics = appContext.getResources().getDisplayMetrics();
+        this.screen.setScale(displayMetrics.density);
+        this.webContext = new WebKitWebContext(automationMode);
+
+        this.networkSession = new WebKitNetworkSession(webContext, automationMode, ephemeralSession,
+                                                       appContext.getFilesDir().getAbsolutePath(),
+                                                       appContext.getCacheDir().getAbsolutePath());
+        this.webKitCookieManager = new WebKitCookieManager(networkSession);
+        this.websiteDataManager = networkSession.getWebsiteDataManager();
+        this.webKitCookieManager.setAcceptPolicy(WebKitCookieManager.WEBKIT_COOKIE_POLICY_ACCEPT_NO_THIRD_PARTY);
+
+        this.settings = new WebKitSettings();
+    }
+
+    /**
+     * Heuristic for picking the default {@code ephemeralSession} on emulators, which typically lack
+     * hardware-backed persistent storage and crash when WebKit tries to create mmap-backed cache files
+     * on emulated filesystems.
+     *
+     * <p>FIXME: emulator detection via {@code Build.PRODUCT}/{@code Build.HARDWARE} is fragile;
+     * callers that know better should pass an explicit value to the 3-arg constructor.
+     */
+    public static boolean shouldUseEphemeralSession() {
+        return android.os.Build.PRODUCT.contains("sdk") || android.os.Build.PRODUCT.contains("vbox") ||
+            android.os.Build.HARDWARE.contains("goldfish") || android.os.Build.HARDWARE.contains("ranchu");
+    }
+
+    public void destroy() {
+        settings.destroy();
+        webKitCookieManager.destroy();
+        networkSession.destroy();
+        webContext.destroy();
+        display.destroy();
+    }
+
+    @NonNull
+    public android.content.Context getApplicationContext() {
+        return appContext;
+    }
+
+    @NonNull
+    public CookieManager getCookieManager() {
+        if (cookieManager == null) {
+            cookieManager = new CookieManager(webKitCookieManager, websiteDataManager);
+        }
+        return cookieManager;
+    }
+
+    // Internal getters for WebView to access proxies.
+    @NonNull
+    WPEDisplay getWPEDisplay() {
+        return display;
+    }
+    @NonNull
+    WPEScreen getWPEScreen() {
+        return screen;
+    }
+    @NonNull
+    WebKitWebContext getWebKitWebContext() {
+        return webContext;
+    }
+    @NonNull
+    WebKitNetworkSession getWebKitNetworkSession() {
+        return networkSession;
+    }
+    @NonNull
+    WebKitSettings getWebKitSettings() {
+        return settings;
+    }
+}

--- a/wpeview/src/main/java/org/wpewebkit/wpeview/WebSettings.java
+++ b/wpeview/src/main/java/org/wpewebkit/wpeview/WebSettings.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package org.wpewebkit.wpeview;
+
+import androidx.annotation.NonNull;
+
+import org.wpewebkit.wpe.WebKitSettings;
+
+/**
+ * WebSettings provides control over the configuration of a {@link WebView}.
+ */
+public class WebSettings {
+    private final WebKitSettings settings;
+
+    WebSettings(@NonNull WebKitSettings settings) { this.settings = settings; }
+
+    public @NonNull String getUserAgentString() { return settings.getUserAgentString(); }
+    public void setUserAgentString(@NonNull String userAgent) { settings.setUserAgentString(userAgent); }
+
+    public boolean getMediaPlaybackRequiresUserGesture() { return settings.getMediaPlaybackRequiresUserGesture(); }
+    public void setMediaPlaybackRequiresUserGesture(boolean require) {
+        settings.setMediaPlaybackRequiresUserGesture(require);
+    }
+
+    public boolean getAllowUniversalAccessFromFileURLs() { return settings.getAllowUniversalAccessFromFileURLs(); }
+    public void setAllowUniversalAccessFromFileURLs(boolean flag) {
+        settings.setAllowUniversalAccessFromFileURLs(flag);
+    }
+
+    public boolean getAllowFileAccessFromFileURLs() { return settings.getAllowFileAccessFromFileURLs(); }
+    public void setAllowFileAccessFromFileURLs(boolean flag) { settings.setAllowFileAccessFromFileURLs(flag); }
+
+    public boolean getDeveloperExtrasEnabled() { return settings.getDeveloperExtrasEnabled(); }
+    public void setDeveloperExtrasEnabled(boolean flag) { settings.setDeveloperExtrasEnabled(flag); }
+
+    public boolean getDisableWebSecurity() { return settings.getDisableWebSecurity(); }
+    public void setDisableWebSecurity(boolean disable) { settings.setDisableWebSecurity(disable); }
+}

--- a/wpeview/src/main/java/org/wpewebkit/wpeview/WebView.java
+++ b/wpeview/src/main/java/org/wpewebkit/wpeview/WebView.java
@@ -1,0 +1,388 @@
+/**
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package org.wpewebkit.wpeview;
+
+import android.annotation.SuppressLint;
+import android.graphics.Color;
+import android.net.Uri;
+import android.util.AttributeSet;
+import android.view.KeyEvent;
+import android.view.MotionEvent;
+import android.view.Surface;
+import android.view.SurfaceHolder;
+import android.view.SurfaceView;
+import android.widget.FrameLayout;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.UiThread;
+
+import org.wpewebkit.wpe.WPEEventType;
+import org.wpewebkit.wpe.WPEToplevel;
+import org.wpewebkit.wpe.WPEView;
+import org.wpewebkit.wpe.WebKitWebView;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * WebView is the public Android widget for the WPE browser engine.
+ * It handles the Surface lifecycle, gestures, and UI delegation.
+ */
+@UiThread
+public class WebView extends FrameLayout {
+    private WebContext wpeContext;
+    private boolean ownsContext;
+    private WebKitWebView webKitWebView;
+    private WPEToplevel wpeToplevel;
+    WPEView platformView;
+    private PageSurfaceView surfaceView;
+    private WebSettings webSettings;
+    private @Nullable Surface attachedSurface;
+
+    WebViewClient viewClient = new WebViewClient();
+    WebChromeClient chromeClient = new WebChromeClient();
+    private @Nullable String originalUrl = null;
+    String currentUrl = "about:blank";
+    String currentTitle = "";
+    int currentProgress = 0;
+    boolean canGoBack = false;
+    boolean canGoForward = false;
+
+    public WebView(@NonNull android.content.Context context) { this(context, (AttributeSet)null); }
+
+    public WebView(@NonNull android.content.Context context, @Nullable AttributeSet attrs) {
+        super(context, attrs);
+        init(new WebContext(context), true);
+    }
+
+    public WebView(@NonNull WebContext context) {
+        super(context.getApplicationContext());
+        init(context, false);
+    }
+
+    private void init(@NonNull WebContext context, boolean ownsContext) {
+        this.wpeContext = context;
+        this.ownsContext = ownsContext;
+
+        this.webKitWebView = new WebKitWebView(wpeContext.getWPEDisplay(), wpeContext.getWebKitWebContext(), null,
+                                               wpeContext.getWebKitNetworkSession(), wpeContext.getWebKitSettings());
+
+        this.platformView = webKitWebView.getWPEView();
+        this.webSettings = new WebSettings(wpeContext.getWebKitSettings());
+        this.wpeToplevel = new WPEToplevel(wpeContext.getWPEDisplay(), null);
+        this.platformView.setToplevel(wpeToplevel);
+
+        this.webKitWebView.setListener(new WebKitWebView.Listener() {
+            @Override
+            public void onClose() {
+                chromeClient.onCloseWindow(WebView.this);
+            }
+
+            @Override
+            public void onPageStarted(String url) {
+                viewClient.onPageStarted(WebView.this, url);
+            }
+
+            @Override
+            public void onPageFinished(String url) {
+                viewClient.onPageFinished(WebView.this, url);
+            }
+
+            @Override
+            public void onURLChanged(String uri) {
+                currentUrl = uri;
+                viewClient.doUpdateVisitedHistory(WebView.this, uri, /* isReload */ false);
+            }
+
+            @Override
+            public void onLoadProgress(double progress) {
+                currentProgress = (int)Math.round(progress * 100);
+                chromeClient.onProgressChanged(WebView.this, currentProgress);
+            }
+
+            @Override
+            public void onTitleChanged(String title, boolean goBack, boolean goForward) {
+                currentTitle = title;
+                canGoBack = goBack;
+                canGoForward = goForward;
+                chromeClient.onReceivedTitle(WebView.this, title);
+            }
+
+            @Override
+            public void onReceivedHttpError(String uri, String method, String mimeType, int statusCode) {
+                WPEResourceRequest request = new HttpResourceRequest(Uri.parse(uri), method);
+                WPEResourceResponse response = new WPEResourceResponse(mimeType, statusCode, Collections.emptyMap());
+                viewClient.onReceivedHttpError(WebView.this, request, response);
+            }
+        });
+
+        this.surfaceView = new PageSurfaceView(getContext());
+        this.surfaceView.getHolder().addCallback(new SurfaceCallback());
+        addView(surfaceView);
+
+        setFocusable(true);
+        setFocusableInTouchMode(true);
+    }
+
+    public void destroy() {
+        if (platformView != null)
+            platformView.setToplevel(null);
+        if (wpeToplevel != null) {
+            wpeToplevel.destroy();
+            wpeToplevel = null;
+        }
+        if (webKitWebView != null) {
+            webKitWebView.destroy();
+            webKitWebView = null;
+        }
+        if (ownsContext && wpeContext != null) {
+            wpeContext.destroy();
+            wpeContext = null;
+        }
+    }
+
+    void attachToplevelSurface(@NonNull Surface surface) {
+        if (wpeContext == null || wpeToplevel == null)
+            return;
+        if (attachedSurface == surface)
+            return;
+        attachedSurface = surface;
+        if (platformView != null)
+            platformView.setToplevel(wpeToplevel);
+        wpeToplevel.onSurfaceCreated(surface);
+
+        int[] size = new int[2];
+        wpeToplevel.getSize(size);
+        if (platformView != null && size[0] > 0 && size[1] > 0) {
+            platformView.resized(size[0], size[1]);
+            platformView.setMapped(true);
+        }
+    }
+
+    void detachToplevelSurface() {
+        if (wpeToplevel != null) {
+            if (platformView != null)
+                platformView.setMapped(false);
+            attachedSurface = null;
+            wpeToplevel.onSurfaceDestroyed();
+        }
+    }
+
+    public void setWebViewClient(@NonNull WebViewClient client) { this.viewClient = client; }
+    public @NonNull WebViewClient getWebViewClient() { return viewClient; }
+
+    public void setWebChromeClient(@NonNull WebChromeClient client) { this.chromeClient = client; }
+    public @NonNull WebChromeClient getWebChromeClient() { return chromeClient; }
+
+    public @NonNull String getUrl() { return currentUrl; }
+    public @Nullable String getOriginalUrl() { return originalUrl; }
+    public @NonNull String getTitle() { return currentTitle; }
+    public int getProgress() { return currentProgress; }
+    public boolean canGoBack() { return canGoBack; }
+    public boolean canGoForward() { return canGoForward; }
+
+    public void loadUrl(@NonNull String url) {
+        originalUrl = url;
+        if (webKitWebView != null)
+            webKitWebView.loadUrl(url);
+    }
+
+    public void loadHtml(@NonNull String content, @Nullable String baseUri) {
+        originalUrl = baseUri;
+        if (webKitWebView != null)
+            webKitWebView.loadHtml(content, baseUri);
+    }
+
+    public void loadData(@NonNull String data, @Nullable String mimeType, @Nullable String encoding) {
+        loadDataWithBaseURL(null, data, mimeType, encoding, null);
+    }
+
+    public void loadDataWithBaseURL(@Nullable String baseUrl, @NonNull String data, @Nullable String mimeType,
+                                    @Nullable String encoding, @Nullable String historyUrl) {
+        // Mirrors android.webkit.WebView.loadDataWithBaseURL: extra args are advisory.
+        // The current backend always parses content as UTF-8 HTML.
+        loadHtml(data, baseUrl);
+    }
+
+    public void goBack() {
+        if (webKitWebView != null)
+            webKitWebView.goBack();
+    }
+    public void goForward() {
+        if (webKitWebView != null)
+            webKitWebView.goForward();
+    }
+    public void reload() {
+        if (webKitWebView != null)
+            webKitWebView.reload();
+    }
+    public void stopLoading() {
+        if (webKitWebView != null)
+            webKitWebView.stopLoading();
+    }
+    public @NonNull WebSettings getSettings() { return webSettings; }
+    public @NonNull CookieManager getCookieManager() { return wpeContext.getCookieManager(); }
+
+    @FunctionalInterface
+    public interface JavascriptCallback {
+        void onResult(@NonNull String result);
+    }
+
+    public void evaluateJavascript(@NonNull String script, @Nullable JavascriptCallback callback) {
+        if (webKitWebView != null)
+            webKitWebView.evaluateJavascript(script, callback != null ? result -> callback.onResult(result) : null);
+    }
+
+    public void setTLSErrorsPolicy(int policy) { wpeContext.getWebKitNetworkSession().setTLSErrorsPolicy(policy); }
+
+    private static class HttpResourceRequest implements WPEResourceRequest {
+        private final Uri uri;
+        private final String method;
+        HttpResourceRequest(Uri uri, String method) {
+            this.uri = uri;
+            this.method = method;
+        }
+        @Override
+        public @NonNull Uri getUrl() {
+            return uri;
+        }
+        @Override
+        public @NonNull String getMethod() {
+            return method;
+        }
+        @Override
+        public @NonNull Map<String, String> getRequestHeaders() {
+            return Collections.emptyMap();
+        }
+    }
+
+    /**
+     * Internal SurfaceView that handles the drawing surface.
+     */
+    class PageSurfaceView extends SurfaceView {
+        public PageSurfaceView(android.content.Context context) {
+            super(context);
+            setBackgroundColor(Color.TRANSPARENT);
+        }
+
+        @Override
+        @SuppressLint("ClickableViewAccessibility")
+        public boolean onTouchEvent(MotionEvent event) {
+            if (platformView == null)
+                return false;
+
+            // MotionEvent coords are in physical pixels; WPE expects logical pixels.
+            float density = getContext().getResources().getDisplayMetrics().density;
+
+            int action = event.getActionMasked();
+            int type;
+            int actionIndex;
+            switch (action) {
+            case MotionEvent.ACTION_DOWN:
+            case MotionEvent.ACTION_POINTER_DOWN:
+                WebView.this.requestFocus();
+                type = WPEEventType.TOUCH_DOWN;
+                actionIndex = event.getActionIndex();
+                platformView.dispatchTouchEvent(
+                    event.getEventTime(), type, 1, new int[] {event.getPointerId(actionIndex)},
+                    new float[] {event.getX(actionIndex) / density}, new float[] {event.getY(actionIndex) / density});
+                return true;
+            case MotionEvent.ACTION_UP:
+            case MotionEvent.ACTION_POINTER_UP:
+                type = WPEEventType.TOUCH_UP;
+                actionIndex = event.getActionIndex();
+                platformView.dispatchTouchEvent(
+                    event.getEventTime(), type, 1, new int[] {event.getPointerId(actionIndex)},
+                    new float[] {event.getX(actionIndex) / density}, new float[] {event.getY(actionIndex) / density});
+                return true;
+            case MotionEvent.ACTION_MOVE:
+                type = WPEEventType.TOUCH_MOVE;
+                break;
+            case MotionEvent.ACTION_CANCEL:
+                type = WPEEventType.TOUCH_CANCEL;
+                break;
+            default:
+                return false;
+            }
+
+            // For MOVE and CANCEL send all active pointers
+            int pointerCount = event.getPointerCount();
+            int[] ids = new int[pointerCount];
+            float[] xs = new float[pointerCount];
+            float[] ys = new float[pointerCount];
+            for (int i = 0; i < pointerCount; i++) {
+                ids[i] = event.getPointerId(i);
+                xs[i] = event.getX(i) / density;
+                ys[i] = event.getY(i) / density;
+            }
+            platformView.dispatchTouchEvent(event.getEventTime(), type, pointerCount, ids, xs, ys);
+            return true;
+        }
+    }
+
+    @Override
+    public boolean dispatchKeyEvent(KeyEvent event) {
+        if (platformView == null)
+            return super.dispatchKeyEvent(event);
+
+        int action = event.getAction();
+        int type;
+        if (action == KeyEvent.ACTION_DOWN)
+            type = WPEEventType.KEYBOARD_KEY_DOWN;
+        else if (action == KeyEvent.ACTION_UP)
+            type = WPEEventType.KEYBOARD_KEY_UP;
+        else
+            return super.dispatchKeyEvent(event);
+
+        platformView.dispatchKeyEvent(event.getEventTime(), type, event.getKeyCode(), event.getUnicodeChar(),
+                                      event.getMetaState());
+        return true;
+    }
+
+    @Override
+    protected void onSizeChanged(int w, int h, int oldw, int oldh) {
+        super.onSizeChanged(w, h, oldw, oldh);
+        if (wpeToplevel != null) {
+            wpeToplevel.setPhysicalSize(w, h);
+            int[] size = new int[2];
+            wpeToplevel.getSize(size);
+            if (platformView != null)
+                platformView.resized(size[0], size[1]);
+        }
+    }
+
+    class SurfaceCallback implements SurfaceHolder.Callback {
+        @Override
+        public void surfaceCreated(SurfaceHolder holder) {
+            attachToplevelSurface(holder.getSurface());
+            viewClient.onViewReady(WebView.this);
+        }
+
+        @Override
+        public void surfaceChanged(SurfaceHolder holder, int format, int width, int height) {
+            attachToplevelSurface(holder.getSurface());
+        }
+
+        @Override
+        public void surfaceDestroyed(SurfaceHolder holder) {
+            detachToplevelSurface();
+        }
+    }
+}

--- a/wpeview/src/main/java/org/wpewebkit/wpeview/WebViewClient.java
+++ b/wpeview/src/main/java/org/wpewebkit/wpeview/WebViewClient.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package org.wpewebkit.wpeview;
+
+import android.net.http.SslError;
+
+import androidx.annotation.NonNull;
+
+/**
+ * WebViewClient provides the high-level navigation and resource callbacks for {@link WebView}.
+ */
+public class WebViewClient {
+    /**
+     * Notify the host application that a page has started loading.
+     * @param view The WebView that is initiating the callback.
+     * @param url The url to be loaded.
+     */
+    public void onPageStarted(@NonNull WebView view, @NonNull String url) {}
+
+    /**
+     * Notify the host application that a page has finished loading.
+     * @param view The WebView that is initiating the callback.
+     * @param url The url of the page.
+     */
+    public void onPageFinished(@NonNull WebView view, @NonNull String url) {}
+
+    /**
+     * Notify the host application that the current page's visited URL has been updated.
+     * Mirrors {@code android.webkit.WebViewClient.doUpdateVisitedHistory}.
+     * @param view The WebView that is initiating the callback.
+     * @param url The URL of the visited page.
+     * @param isReload True if this URL was reached as the result of a reload.
+     */
+    // FIXME: plumb the isReload flag through WebKitWebView.Listener; currently always false.
+    public void doUpdateVisitedHistory(@NonNull WebView view, @NonNull String url, boolean isReload) {}
+
+    /**
+     * Notify the host application that the internal SurfaceView has been created
+     * and is ready to render to its surface.
+     * @param view The WebView that is initiating the callback.
+     */
+    public void onViewReady(@NonNull WebView view) {}
+
+    /**
+     * Notify the host application that an HTTP error has been received from the server while
+     * loading a resource. HTTP errors have status codes >= 400.
+     * @param view The WebView that is initiating the callback.
+     * @param request The originating request.
+     * @param errorResponse Information about the error occurred.
+     */
+    public void onReceivedHttpError(@NonNull WebView view, @NonNull WPEResourceRequest request,
+                                    @NonNull WPEResourceResponse errorResponse) {}
+
+    /**
+     * The interface used to accept or reject an invalid SSL certificate.
+     */
+    public interface SslErrorHandler {
+        /** Call this method to accept an invalid SSL certificate. */
+        void proceed();
+
+        /** Call this method to reject an invalid SSL certificate. */
+        void cancel();
+    }
+
+    /**
+     * Notify the host application that an HTTPS resource failed to load due to SSL errors.
+     * @param view The WebView that is initiating the callback.
+     * @param handler The host application must call either proceed() or cancel().
+     * @param error The SSL error(s) which happened.
+     */
+    // FIXME: wire webkit_web_view tls-errors signal to invoke this callback.
+    public void onReceivedSslError(@NonNull WebView view, @NonNull SslErrorHandler handler, @NonNull SslError error) {}
+}


### PR DESCRIPTION
Adds a high-level API in org.wpewebkit.wpeview keeping the CAPI closer to the WPE/WebKit API. The new classes are based on android.webkit.WebView so existing Android docs and idioms can be used.
  - WebChromeClient.java: high-level chrome/UI callback adapter for WebView (parity with android.webkit.WebChromeClient).
  - WebViewClient.java: high-level navigation/resource callback adapter for WebView (parity with android.webkit.WebViewClient). Includes doUpdateVisitedHistory() in place of the previous onUriChanged notification on the chrome client.
  - WebContext.java: shared context object wrapping the new low-level display, session, settings, and cookie state. Exposes an explicit ephemeralSession flag, with a shouldUseEphemeralSession() helper for the emulator-storage workaround.
  - WebSettings.java: high-level settings over WebKitSettings.
  - CookieManager.java: high-level cookie policy API.
  - WebView.java: new high-level Android widget built on the WPE CAPI bridge. Touch and key events use the new org.wpewebkit.wpe.WPEEventType constants.
  - WPEEventType.java: Java mirror of the WPEEventType enum from WPEEvent.h, replacing inline magic numbers in WebView.

This commit is additive only: the legacy WPEView/WPEContext API remains unchanged and existing consumers can continue using it. Deprecation of the legacy API will land in a follow-up once consumers have migrated.