### PR TITLE
MiniBrowser: Port to the new convenience API

### DIFF
--- a/tools/minibrowser/src/main/AndroidManifest.xml
+++ b/tools/minibrowser/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-feature
         android:name="android.hardware.touchscreen"
@@ -24,6 +25,8 @@
     </queries>
 
     <application
+        android:name=".MiniBrowserApplication"
+        tools:replace="android:name"
         android:banner="@drawable/banner"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/tools/minibrowser/src/main/java/org/wpewebkit/tools/minibrowser/BrowserFragment.kt
+++ b/tools/minibrowser/src/main/java/org/wpewebkit/tools/minibrowser/BrowserFragment.kt
@@ -20,7 +20,6 @@
 package org.wpewebkit.tools.minibrowser
 
 import android.content.Context
-import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import android.view.*
@@ -33,9 +32,9 @@ import androidx.navigation.fragment.findNavController
 import org.wpewebkit.tools.minibrowser.R
 import org.wpewebkit.tools.minibrowser.databinding.FragmentBrowserBinding
 import org.wpewebkit.tools.minibrowser.requestApplyStandardInsets
-import org.wpewebkit.wpeview.WPEChromeClient
-import org.wpewebkit.wpeview.WPEView
-import org.wpewebkit.wpeview.WPEViewClient
+import org.wpewebkit.wpeview.WebChromeClient
+import org.wpewebkit.wpeview.WebView
+import org.wpewebkit.wpeview.WebViewClient
 
 
 const val INITIAL_URL = "https://igalia.com"
@@ -105,80 +104,63 @@ class BrowserFragment : Fragment(R.layout.fragment_browser) {
         currentState.selectedTabId?.let { selectedTabId ->
             val tab = browserViewModel.findTab(selectedTabId)
             binding.tabContainerView.addView(tab.webview)
-            tab.webview.url.let {
-                binding.toolbarEditText.setText(tab.webview.url)
-            }
-        } ?:run {
-            val tab = Tab.newTab(requireContext(), INITIAL_URL)
+            binding.toolbarEditText.setText(tab.webview.url)
+        } ?: run {
+            val app = requireContext().applicationContext as MiniBrowserApplication
+            val tab = Tab.newTab(app.browserContext, INITIAL_URL)
             browserViewModel.addTab(tab)
             binding.tabContainerView.addView(tab.webview)
             binding.toolbarEditText.setText(tab.webview.url)
         }
 
         val selectedTab = selectedTab()
-        if (selectedTab.webview.wpeChromeClient == null) {
-            selectedTab.webview.wpeChromeClient = object : WPEChromeClient {
-                override fun onProgressChanged(view: WPEView, progress: Int) {
-                    super.onProgressChanged(view, progress)
-                    binding.pageProgress.progress = progress
-                    if (progress in 1..99) {
-                        binding.pageProgress.visibility = View.VISIBLE
-                    } else {
-                        binding.pageProgress.visibility = View.GONE
-                    }
-                }
-
-                override fun onShowCustomView(view: View, callback: WPEChromeClient.CustomViewCallback) {
-                    fullscreenView?.let {
-                        (it.parent as ViewGroup).removeView(it)
-                    }
-                    fullscreenView = view
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                        requireActivity().window.insetsController?.hide(
-                            WindowInsets.Type.statusBars() or WindowInsets
-                            .Type.navigationBars())
-                    } else {
-                        @Suppress("DEPRECATION")
-                        requireActivity().window.setFlags(
-                            WindowManager.LayoutParams.FLAG_FULLSCREEN,
-                            WindowManager.LayoutParams.FLAG_FULLSCREEN
-                        )
-                    }
-                    requireActivity().window.addContentView(
-                        fullscreenView,
-                        FrameLayout.LayoutParams(
-                            ViewGroup.LayoutParams.MATCH_PARENT,
-                            ViewGroup.LayoutParams.MATCH_PARENT, Gravity.CENTER
-                        )
-                    )
-                }
-
-                override fun onHideCustomView() {
-                    fullscreenView?.let {
-                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                            requireActivity().window.insetsController?.show(WindowInsets.Type.statusBars() or WindowInsets.Type.navigationBars())
-                        } else {
-                            @Suppress("DEPRECATION")
-                            requireActivity().window.clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN)
-                        }
-                        (it.parent as ViewGroup).removeView(it)
-                    }
-                    fullscreenView = null
-                }
-
-                override fun onUriChanged(view: WPEView, uri: String) {
-                    super.onUriChanged(view, uri)
-                    binding.toolbarEditText.setText(uri)
+        selectedTab.webview.setWebChromeClient(object : WebChromeClient() {
+            override fun onProgressChanged(view: WebView, progress: Int) {
+                binding.pageProgress.progress = progress
+                if (progress in 1..99) {
+                    binding.pageProgress.visibility = View.VISIBLE
+                } else {
+                    binding.pageProgress.visibility = View.GONE
                 }
             }
-        }
 
-        selectedTab.webview.wpeViewClient = object : WPEViewClient() {
-            override fun onPageStarted(view: WPEView, url: String) {
-                super.onPageStarted(view, url)
+            override fun onShowCustomView(view: View, callback: WebChromeClient.CustomViewCallback) {
+                fullscreenView?.let {
+                    (it.parent as ViewGroup).removeView(it)
+                }
+                fullscreenView = view
+                requireActivity().window.insetsController?.hide(
+                    WindowInsets.Type.statusBars() or WindowInsets.Type.navigationBars()
+                )
+                requireActivity().window.addContentView(
+                    fullscreenView,
+                    FrameLayout.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.MATCH_PARENT, Gravity.CENTER
+                    )
+                )
+            }
+
+            override fun onHideCustomView() {
+                fullscreenView?.let {
+                    requireActivity().window.insetsController?.show(
+                        WindowInsets.Type.statusBars() or WindowInsets.Type.navigationBars()
+                    )
+                    (it.parent as ViewGroup).removeView(it)
+                }
+                fullscreenView = null
+            }
+        })
+
+        selectedTab.webview.setWebViewClient(object : WebViewClient() {
+            override fun onPageStarted(view: WebView, url: String) {
                 binding.toolbarEditText.setText(url)
             }
-        }
+
+            override fun doUpdateVisitedHistory(view: WebView, url: String, isReload: Boolean) {
+                binding.toolbarEditText.setText(url)
+            }
+        })
     }
 
     override fun onStart() {

--- a/tools/minibrowser/src/main/java/org/wpewebkit/tools/minibrowser/MiniBrowserApplication.kt
+++ b/tools/minibrowser/src/main/java/org/wpewebkit/tools/minibrowser/MiniBrowserApplication.kt
@@ -1,6 +1,5 @@
 /**
- * Copyright (C) 2022 Igalia S.L. <info@igalia.com>
- *   Author: Jani Hautakangas <jani@igalia.com>
+ * Copyright (C) 2026 Igalia S.L.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -19,25 +18,17 @@
 
 package org.wpewebkit.tools.minibrowser
 
-import org.wpewebkit.wpeview.WebView
+import org.wpewebkit.WPEApplication
+import org.wpewebkit.WPEApplication.ProcessKind
 import org.wpewebkit.wpeview.WebContext as BrowserContext
-import java.util.UUID
 
-data class Tab(
-    val id: String,
-    val webview: WebView
-) {
-    companion object {
-        fun newTab(
-            browserContext: BrowserContext,
-            url: String
-        ) : Tab {
-            return Tab(
-                UUID.randomUUID().toString(),
-                WebView(browserContext).apply {
-                    loadUrl(url)
-                }
-            )
+class MiniBrowserApplication : WPEApplication() {
+    lateinit var browserContext: BrowserContext
+
+    override fun onCreate() {
+        super.onCreate()
+        if (processKind == ProcessKind.MAIN) {
+            browserContext = BrowserContext(this)
         }
     }
 }

--- a/wpeview/src/main/java/org/wpewebkit/WPEApplication.java
+++ b/wpeview/src/main/java/org/wpewebkit/WPEApplication.java
@@ -24,10 +24,12 @@ import android.app.Application;
 import android.os.Bundle;
 import android.util.Log;
 
+import androidx.annotation.NonNull;
+
 public class WPEApplication extends Application {
     static final String LOGTAG = "WPEApplication";
 
-    private enum ProcessKind {
+    public enum ProcessKind {
         MAIN {
             @Override
             public String[] getLibraryNames() {
@@ -53,6 +55,7 @@ public class WPEApplication extends Application {
             }
         };
 
+        @NonNull
         abstract public String[] getLibraryNames();
     }
 


### PR DESCRIPTION
Migrate from the legacy WPEView API to the new high-level convenience API introduced in the previous commit.

  - WPEView/WPEContext → WebView/WebContext (shared per-app via new MiniBrowserApplication holder).
  - WPEChromeClient/WPEViewClient → WebChromeClient/WebViewClient.
  - URL-bar update moved from onUriChanged (chrome client) to doUpdateVisitedHistory (view client).
  - AndroidManifest declares MiniBrowserApplication as the app's Application class via tools:replace="android:name", overriding the library's default WPEApplication.
  - WPEApplication.ProcessKind is made public (with @NonNull on the getLibraryNames() return type) so MiniBrowserApplication can reuse the existing process-kind classification instead of re-parsing the process name.

The legacy WPEView API will be removed in a follow-up once all the apps using it are ported.