### PR TITLE
Convenience API: Add keyboard and IME support

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -99,6 +99,7 @@ Java code lives in `wpeview/src/main/java/org/wpewebkit/wpe/`:
 - `WebKitCookieManager` wraps a native `WebKitCookieManager`.
 - `WebKitSettings` wraps a native `WebKitSettings`.
 - `WPEDisplay` wraps a native `WPEDisplay`.
+- `WPEInputMethodContext` wraps a native `WPEInputMethodContext` borrowed from a `WPEView`.
 - `WPEScreen` wraps a native `WPEScreen`.
 - `WPEToplevel` wraps a native `WPEToplevel`.
 - `WPEView` wraps a native `WPEView`.
@@ -114,6 +115,7 @@ Java proxy names and the native types they expose:
 - `WebKitCookieManager.cpp`
 - `WebKitSettings.cpp`
 - `WPEDisplay.cpp`
+- `WPEInputMethodContext.cpp`
 - `WPEScreen.cpp`
 - `WPEToplevel.cpp`
 - `WPEView.cpp`
@@ -193,6 +195,7 @@ Borrowed proxies:
 | Java class | Native owner |
 | --- | --- |
 | `WPEView` | Borrowed from `WebKitWebView`. It must not outlive the parent `WebKitWebView`. |
+| `WPEInputMethodContext` | Borrowed from `WebKitWebView` (attached to the borrowed `WPEView`); `destroy()` clears the focus listener and drops its JNI global ref. Must not outlive the parent `WebKitWebView`. |
 | `WPEScreen` | Borrowed from `WPEDisplay`. It must not outlive the parent `WPEDisplay`. |
 | `WebKitWebsiteDataManager` | Borrowed from `WebKitNetworkSession`. It must not outlive the parent `WebKitNetworkSession`. |
 

--- a/wpeview/src/main/cpp/CMakeLists.txt
+++ b/wpeview/src/main/cpp/CMakeLists.txt
@@ -150,6 +150,7 @@ add_library(
     capi/WebKitWebView.cpp
     capi/WebKitWebsiteDataManager.cpp
     capi/WPEDisplay.cpp
+    capi/WPEInputMethodContext.cpp
     capi/WPEScreen.cpp
     capi/WPEToplevel.cpp
     capi/WPEView.cpp)

--- a/wpeview/src/main/cpp/Platform/WPEInputMethodContextAndroid.cpp
+++ b/wpeview/src/main/cpp/Platform/WPEInputMethodContextAndroid.cpp
@@ -22,14 +22,35 @@
 
 struct _WPEInputMethodContextAndroid {
     WPEInputMethodContext parent;
+    WPEInputMethodContextAndroidFocusCallback focusInCallback;
+    WPEInputMethodContextAndroidFocusCallback focusOutCallback;
+    gpointer focusCallbackUserData;
 };
 
 G_DEFINE_FINAL_TYPE(WPEInputMethodContextAndroid, wpe_input_method_context_android, WPE_TYPE_INPUT_METHOD_CONTEXT)
+
+static GQuark wpeInputMethodContextAndroidViewQuark()
+{
+    static GQuark quark = g_quark_from_static_string("wpe-input-method-context-android");
+    return quark;
+}
+
+static void wpeInputMethodContextAndroidDispose(GObject* object)
+{
+    auto* self = WPE_INPUT_METHOD_CONTEXT_ANDROID(object);
+    auto* view = wpe_input_method_context_get_view(WPE_INPUT_METHOD_CONTEXT(self));
+    // The view holds a non-owning back-reference; clear it if it still points at us.
+    if (view && g_object_get_qdata(G_OBJECT(view), wpeInputMethodContextAndroidViewQuark()) == self)
+        g_object_set_qdata(G_OBJECT(view), wpeInputMethodContextAndroidViewQuark(), nullptr);
+
+    G_OBJECT_CLASS(wpe_input_method_context_android_parent_class)->dispose(object);
+}
 
 static void wpeInputMethodContextAndroidGetPreeditString(
     WPEInputMethodContext* context, gchar** text, GList** underlines, guint* cursorOffset)
 {
     UNUSED_PARAM(context);
+    // Preedit is not supported: BaseInputConnection's composing text is forwarded as committed text.
     if (text)
         *text = nullptr;
     if (underlines)
@@ -38,10 +59,35 @@ static void wpeInputMethodContextAndroidGetPreeditString(
         *cursorOffset = 0;
 }
 
+static void wpeInputMethodContextAndroidFocusIn(WPEInputMethodContext* context)
+{
+    auto* self = WPE_INPUT_METHOD_CONTEXT_ANDROID(context);
+    if (self->focusInCallback)
+        self->focusInCallback(self->focusCallbackUserData);
+}
+
+static void wpeInputMethodContextAndroidFocusOut(WPEInputMethodContext* context)
+{
+    auto* self = WPE_INPUT_METHOD_CONTEXT_ANDROID(context);
+    if (self->focusOutCallback)
+        self->focusOutCallback(self->focusCallbackUserData);
+}
+
+static void wpeInputMethodContextAndroidReset(WPEInputMethodContext* context)
+{
+    UNUSED_PARAM(context);
+}
+
 static void wpe_input_method_context_android_class_init(WPEInputMethodContextAndroidClass* klass)
 {
+    GObjectClass* objectClass = G_OBJECT_CLASS(klass);
+    objectClass->dispose = wpeInputMethodContextAndroidDispose;
+
     WPEInputMethodContextClass* imContextClass = WPE_INPUT_METHOD_CONTEXT_CLASS(klass);
     imContextClass->get_preedit_string = wpeInputMethodContextAndroidGetPreeditString;
+    imContextClass->focus_in = wpeInputMethodContextAndroidFocusIn;
+    imContextClass->focus_out = wpeInputMethodContextAndroidFocusOut;
+    imContextClass->reset = wpeInputMethodContextAndroidReset;
 }
 
 static void wpe_input_method_context_android_init(WPEInputMethodContextAndroid* context)
@@ -52,5 +98,41 @@ static void wpe_input_method_context_android_init(WPEInputMethodContextAndroid* 
 WPEInputMethodContext* wpe_input_method_context_android_new(WPEView* view)
 {
     g_return_val_if_fail(WPE_IS_VIEW(view), nullptr);
-    return WPE_INPUT_METHOD_CONTEXT(g_object_new(WPE_TYPE_INPUT_METHOD_CONTEXT_ANDROID, "view", view, nullptr));
+    auto* context
+        = WPE_INPUT_METHOD_CONTEXT(g_object_new(WPE_TYPE_INPUT_METHOD_CONTEXT_ANDROID, "view", view, nullptr));
+    // Non-owning back-reference so JNI bridges can resolve the current IM context from a WPEView*.
+    // WebKit owns the strong reference via wpe_view_set_input_method_context().
+    g_object_set_qdata(G_OBJECT(view), wpeInputMethodContextAndroidViewQuark(), context);
+    return context;
+}
+
+WPEInputMethodContextAndroid* wpe_input_method_context_android_from_view(WPEView* view)
+{
+    g_return_val_if_fail(WPE_IS_VIEW(view), nullptr);
+    auto* context = g_object_get_qdata(G_OBJECT(view), wpeInputMethodContextAndroidViewQuark());
+    return context ? WPE_INPUT_METHOD_CONTEXT_ANDROID(context) : nullptr;
+}
+
+void wpe_input_method_context_android_set_focus_callbacks(WPEInputMethodContextAndroid* context,
+    WPEInputMethodContextAndroidFocusCallback focusIn, WPEInputMethodContextAndroidFocusCallback focusOut,
+    gpointer userData)
+{
+    g_return_if_fail(WPE_IS_INPUT_METHOD_CONTEXT_ANDROID(context));
+    context->focusInCallback = focusIn;
+    context->focusOutCallback = focusOut;
+    context->focusCallbackUserData = userData;
+}
+
+void wpe_input_method_context_android_commit_text(WPEInputMethodContextAndroid* context, const char* text)
+{
+    g_return_if_fail(WPE_IS_INPUT_METHOD_CONTEXT_ANDROID(context));
+    g_return_if_fail(text != nullptr);
+    g_signal_emit_by_name(context, "committed", text);
+}
+
+void wpe_input_method_context_android_delete_surrounding(
+    WPEInputMethodContextAndroid* context, int offset, unsigned int count)
+{
+    g_return_if_fail(WPE_IS_INPUT_METHOD_CONTEXT_ANDROID(context));
+    g_signal_emit_by_name(context, "delete-surrounding", offset, count);
 }

--- a/wpeview/src/main/cpp/Platform/WPEInputMethodContextAndroid.h
+++ b/wpeview/src/main/cpp/Platform/WPEInputMethodContextAndroid.h
@@ -27,6 +27,19 @@ G_BEGIN_DECLS
 G_DECLARE_FINAL_TYPE(WPEInputMethodContextAndroid, wpe_input_method_context_android, WPE, INPUT_METHOD_CONTEXT_ANDROID,
     WPEInputMethodContext)
 
+using WPEInputMethodContextAndroidFocusCallback = void (*)(gpointer userData);
+
 WPEInputMethodContext* wpe_input_method_context_android_new(WPEView* view);
+
+WPEInputMethodContextAndroid* wpe_input_method_context_android_from_view(WPEView* view);
+
+void wpe_input_method_context_android_set_focus_callbacks(WPEInputMethodContextAndroid* context,
+    WPEInputMethodContextAndroidFocusCallback focusIn, WPEInputMethodContextAndroidFocusCallback focusOut,
+    gpointer userData);
+
+void wpe_input_method_context_android_commit_text(WPEInputMethodContextAndroid* context, const char* text);
+
+void wpe_input_method_context_android_delete_surrounding(
+    WPEInputMethodContextAndroid* context, int offset, unsigned int count);
 
 G_END_DECLS

--- a/wpeview/src/main/cpp/capi/JNIMappings.cpp
+++ b/wpeview/src/main/cpp/capi/JNIMappings.cpp
@@ -30,6 +30,7 @@ void configureWebKitWebViewEvalCallbackHolderJNIMappings();
 void configureWebKitWebsiteDataManagerJNIMappings();
 void configureWebKitWebsiteDataManagerCallbackHolderJNIMappings();
 void configureWPEDisplayJNIMappings();
+void configureWPEInputMethodContextJNIMappings();
 void configureWPEScreenJNIMappings();
 void configureWPEToplevelJNIMappings();
 void configureWPEViewJNIMappings();
@@ -46,6 +47,7 @@ void configureJNIMappings()
     configureWebKitWebsiteDataManagerJNIMappings();
     configureWebKitWebsiteDataManagerCallbackHolderJNIMappings();
     configureWPEDisplayJNIMappings();
+    configureWPEInputMethodContextJNIMappings();
     configureWPEScreenJNIMappings();
     configureWPEToplevelJNIMappings();
     configureWPEViewJNIMappings();

--- a/wpeview/src/main/cpp/capi/WPEInputMethodContext.cpp
+++ b/wpeview/src/main/cpp/capi/WPEInputMethodContext.cpp
@@ -1,0 +1,169 @@
+/**
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include "JNI/JNI.h"
+#include "Logging.h"
+#include "WPEInputMethodContextAndroid.h"
+
+#include <wpe/wpe-platform.h>
+
+DECLARE_JNI_CLASS_SIGNATURE(JNIWPEInputMethodContext, "org/wpewebkit/wpe/WPEInputMethodContext");
+DECLARE_JNI_CLASS_SIGNATURE(
+    JNIWPEInputMethodContextFocusListener, "org/wpewebkit/wpe/WPEInputMethodContext$FocusListenerHolder");
+
+namespace WebKit {
+
+class JNIWPEInputMethodContextFocusListenerCache final : public JNI::TypedClass<JNIWPEInputMethodContextFocusListener> {
+public:
+    JNIWPEInputMethodContextFocusListenerCache()
+        : JNI::TypedClass<JNIWPEInputMethodContextFocusListener>(true)
+        , m_onFocusIn(getMethod<void()>("onFocusIn"))
+        , m_onFocusOut(getMethod<void()>("onFocusOut"))
+    {
+    }
+
+    void onFocusIn(JNIWPEInputMethodContextFocusListener listener) const
+    {
+        try {
+            m_onFocusIn.invoke(listener);
+        } catch (const std::exception& ex) {
+            Logging::logError("cannot call WPEInputMethodContext focus-in callback (%s)", ex.what());
+        }
+    }
+
+    void onFocusOut(JNIWPEInputMethodContextFocusListener listener) const
+    {
+        try {
+            m_onFocusOut.invoke(listener);
+        } catch (const std::exception& ex) {
+            Logging::logError("cannot call WPEInputMethodContext focus-out callback (%s)", ex.what());
+        }
+    }
+
+private:
+    // NOLINTBEGIN(cppcoreguidelines-avoid-const-or-ref-data-members)
+    const JNI::Method<void()> m_onFocusIn;
+    const JNI::Method<void()> m_onFocusOut;
+    // NOLINTEND(cppcoreguidelines-avoid-const-or-ref-data-members)
+};
+
+const JNIWPEInputMethodContextFocusListenerCache& getJNIFocusListenerCache()
+{
+    static const JNIWPEInputMethodContextFocusListenerCache s_singleton;
+    return s_singleton;
+}
+
+namespace {
+
+    struct FocusListenerHolder {
+        JNI::GlobalRef<JNIWPEInputMethodContextFocusListener> ref;
+    };
+
+    GQuark focusListenerQuark()
+    {
+        static GQuark quark = g_quark_from_static_string("wpe-im-context-android-focus-listener");
+        return quark;
+    }
+
+    void destroyFocusListenerHolder(gpointer ptr) noexcept
+    {
+        delete static_cast<FocusListenerHolder*>(ptr);
+    }
+
+    void onFocusInThunk(gpointer userData)
+    {
+        auto* holder = static_cast<FocusListenerHolder*>(userData);
+        if (holder && holder->ref)
+            getJNIFocusListenerCache().onFocusIn(holder->ref.get());
+    }
+
+    void onFocusOutThunk(gpointer userData)
+    {
+        auto* holder = static_cast<FocusListenerHolder*>(userData);
+        if (holder && holder->ref)
+            getJNIFocusListenerCache().onFocusOut(holder->ref.get());
+    }
+
+} // namespace
+
+class JNIWPEInputMethodContextCache final : public JNI::TypedClass<JNIWPEInputMethodContext> {
+public:
+    JNIWPEInputMethodContextCache()
+        : JNI::TypedClass<JNIWPEInputMethodContext>(true)
+    {
+        registerNativeMethods(JNI::NativeMethod<void(jlong, jstring)>("nativeCommitText", nativeCommitText),
+            JNI::NativeMethod<void(jlong, jint, jint)>("nativeDeleteSurrounding", nativeDeleteSurrounding),
+            JNI::NativeMethod<void(jlong, JNIWPEInputMethodContextFocusListener)>(
+                "nativeSetFocusListener", nativeSetFocusListener),
+            JNI::StaticNativeMethod<jlong(jlong)>("nativeGetForView", nativeGetForView));
+    }
+
+private:
+    static void nativeCommitText(JNIEnv* env, jobject, jlong nativePtr, jstring text)
+    {
+        // GetStringUTFChars returns modified UTF-8 (CESU-8), which mangles supplementary characters
+        // like emoji. Go through UTF-16 + g_utf16_to_utf8 to produce standard UTF-8 for WebKit.
+        const jchar* chars = env->GetStringChars(text, nullptr);
+        const jsize len = env->GetStringLength(text);
+        g_autofree gchar* utf8
+            = g_utf16_to_utf8(reinterpret_cast<const gunichar2*>(chars), len, nullptr, nullptr, nullptr);
+        env->ReleaseStringChars(text, chars);
+        wpe_input_method_context_android_commit_text(JNI::from_jlong<WPEInputMethodContextAndroid>(nativePtr), utf8);
+    }
+
+    static void nativeDeleteSurrounding(JNIEnv*, jobject, jlong nativePtr, jint offset, jint count)
+    {
+        wpe_input_method_context_android_delete_surrounding(
+            JNI::from_jlong<WPEInputMethodContextAndroid>(nativePtr), offset, static_cast<unsigned int>(count));
+    }
+
+    static void nativeSetFocusListener(
+        JNIEnv* env, jobject, jlong nativePtr, JNIWPEInputMethodContextFocusListener listener)
+    {
+        auto* context = JNI::from_jlong<WPEInputMethodContextAndroid>(nativePtr);
+        if (listener) {
+            auto* holder
+                = new FocusListenerHolder {JNI::GlobalRef<JNIWPEInputMethodContextFocusListener>(env, listener)};
+            // qdata owns the holder: the destroy notify runs on context dispose and on listener replacement.
+            g_object_set_qdata_full(G_OBJECT(context), focusListenerQuark(), holder, destroyFocusListenerHolder);
+            wpe_input_method_context_android_set_focus_callbacks(context, onFocusInThunk, onFocusOutThunk, holder);
+        } else {
+            wpe_input_method_context_android_set_focus_callbacks(context, nullptr, nullptr, nullptr);
+            g_object_set_qdata(G_OBJECT(context), focusListenerQuark(), nullptr);
+        }
+    }
+
+    static jlong nativeGetForView(JNIEnv*, jclass, jlong viewPtr)
+    {
+        return reinterpret_cast<jlong>(wpe_input_method_context_android_from_view(JNI::from_jlong<WPEView>(viewPtr)));
+    }
+};
+
+const JNIWPEInputMethodContextCache& getJNIWPEInputMethodContextCache()
+{
+    static const JNIWPEInputMethodContextCache s_singleton;
+    return s_singleton;
+}
+
+void configureWPEInputMethodContextJNIMappings()
+{
+    getJNIFocusListenerCache();
+    getJNIWPEInputMethodContextCache();
+}
+
+} // namespace WebKit

--- a/wpeview/src/main/java/org/wpewebkit/wpe/WPEInputMethodContext.java
+++ b/wpeview/src/main/java/org/wpewebkit/wpe/WPEInputMethodContext.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package org.wpewebkit.wpe;
+
+import androidx.annotation.Keep;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+/**
+ * WPEInputMethodContext is a borrowed JNI proxy for the native WPEInputMethodContext that WebKit
+ * attaches to a WPEView. The native context is owned by WebKit; this wrapper must not outlive the
+ * parent WebKitWebView.
+ */
+public final class WPEInputMethodContext {
+    public interface FocusListener {
+        void onFocusIn();
+        void onFocusOut();
+    }
+
+    private long mNativePtr = 0;
+    public long getNativePtr() { return mNativePtr; }
+
+    WPEInputMethodContext(long nativePtr) { this.mNativePtr = nativePtr; }
+
+    public void commitText(@NonNull String text) { nativeCommitText(mNativePtr, text); }
+
+    public void deleteSurrounding(int offset, int count) { nativeDeleteSurrounding(mNativePtr, offset, count); }
+
+    public void setFocusListener(@Nullable FocusListener listener) {
+        nativeSetFocusListener(mNativePtr, listener != null ? new FocusListenerHolder(listener) : null);
+    }
+
+    void invalidate() { mNativePtr = 0; }
+
+    static long getForView(@NonNull WPEView view) { return nativeGetForView(view.getNativePtr()); }
+
+    private static class FocusListenerHolder {
+        private final FocusListener delegate;
+
+        FocusListenerHolder(@NonNull FocusListener delegate) { this.delegate = delegate; }
+
+        @Keep
+        public void onFocusIn() {
+            MainLooperDispatcher.post(delegate::onFocusIn);
+        }
+
+        @Keep
+        public void onFocusOut() {
+            MainLooperDispatcher.post(delegate::onFocusOut);
+        }
+    }
+
+    private native void nativeCommitText(long nativePtr, String text);
+    private native void nativeDeleteSurrounding(long nativePtr, int offset, int count);
+    private native void nativeSetFocusListener(long nativePtr, @Nullable FocusListenerHolder listener);
+    private static native long nativeGetForView(long viewPtr);
+}

--- a/wpeview/src/main/java/org/wpewebkit/wpe/WebKitWebView.java
+++ b/wpeview/src/main/java/org/wpewebkit/wpe/WebKitWebView.java
@@ -28,6 +28,7 @@ import androidx.annotation.Nullable;
 public final class WebKitWebView {
     private long mNativePtr = 0;
     private final WPEView wpeView;
+    private final WPEInputMethodContext inputMethodContext;
     private final WebKitSettings settings;
     private final WebKitNetworkSession networkSession;
 
@@ -43,9 +44,12 @@ public final class WebKitWebView {
             display.getNativePtr(), context.getWebKitWebContextPtr(), toplevel != null ? toplevel.getNativePtr() : 0,
             networkSession != null ? networkSession.getNativePtr() : 0, settings != null ? settings.getNativePtr() : 0);
         wpeView = new WPEView(nativeGetWPEView(mNativePtr));
+        inputMethodContext = new WPEInputMethodContext(WPEInputMethodContext.getForView(wpeView));
     }
 
     public @NonNull WPEView getWPEView() { return wpeView; }
+
+    public @NonNull WPEInputMethodContext getInputMethodContext() { return inputMethodContext; }
 
     public @Nullable WebKitSettings getSettings() { return settings; }
 
@@ -100,10 +104,13 @@ public final class WebKitWebView {
     }
 
     public void destroy() {
+        // Must run before nativeDestroy: the focus listener cleanup needs the live IM context.
+        inputMethodContext.setFocusListener(null);
         if (mNativePtr != 0) {
             nativeDestroy(mNativePtr);
             mNativePtr = 0;
         }
+        inputMethodContext.invalidate();
         wpeView.invalidate();
     }
 

--- a/wpeview/src/main/java/org/wpewebkit/wpeview/WPEInputConnection.java
+++ b/wpeview/src/main/java/org/wpewebkit/wpeview/WPEInputConnection.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package org.wpewebkit.wpeview;
+
+import android.view.KeyEvent;
+import android.view.inputmethod.BaseInputConnection;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import org.wpewebkit.wpe.WPEInputMethodContext;
+
+/**
+ * Bridges Android IME input to WebKit by translating BaseInputConnection callbacks into
+ * WPEInputMethodContext operations. deleteSurroundingText is split into before/after halves
+ * because WPE's "delete-surrounding" signal is single-sided; sendKeyEvent goes through the parent
+ * WebView so IME-synthesised hardware keys follow the same path as physical key presses.
+ */
+public class WPEInputConnection extends BaseInputConnection {
+    private final WebView webView;
+    private final WPEInputMethodContext imContext;
+
+    public WPEInputConnection(@NonNull WebView webView, boolean fullEditor, @NonNull WPEInputMethodContext imContext) {
+        super(webView, fullEditor);
+        this.webView = webView;
+        this.imContext = imContext;
+    }
+
+    @Override
+    public boolean commitText(@Nullable CharSequence text, int newCursorPosition) {
+        if (text == null || text.length() == 0)
+            return true;
+        imContext.commitText(text.toString());
+        return true;
+    }
+
+    @Override
+    public boolean deleteSurroundingText(int beforeLength, int afterLength) {
+        // Java char units per BaseInputConnection contract: supplementary chars count as 2.
+        if (beforeLength > 0)
+            imContext.deleteSurrounding(-beforeLength, beforeLength);
+        if (afterLength > 0)
+            imContext.deleteSurrounding(0, afterLength);
+        return true;
+    }
+
+    @Override
+    public boolean deleteSurroundingTextInCodePoints(int beforeLength, int afterLength) {
+        // We don't track the local text buffer, so codepoint counts cannot be translated to char
+        // counts accurately; for BMP-only text the two are equivalent.
+        return deleteSurroundingText(beforeLength, afterLength);
+    }
+
+    @Override
+    public boolean setComposingText(@Nullable CharSequence text, int newCursorPosition) {
+        // Preedit is not wired through WPE yet; commit as final text.
+        return commitText(text, newCursorPosition);
+    }
+
+    @Override
+    public boolean finishComposingText() {
+        return true;
+    }
+
+    @Override
+    public boolean sendKeyEvent(@NonNull KeyEvent event) {
+        return webView.dispatchKeyEvent(event);
+    }
+}

--- a/wpeview/src/main/java/org/wpewebkit/wpeview/WebView.java
+++ b/wpeview/src/main/java/org/wpewebkit/wpeview/WebView.java
@@ -19,6 +19,7 @@
 package org.wpewebkit.wpeview;
 
 import android.annotation.SuppressLint;
+import android.content.Context;
 import android.graphics.Color;
 import android.net.Uri;
 import android.util.AttributeSet;
@@ -27,6 +28,9 @@ import android.view.MotionEvent;
 import android.view.Surface;
 import android.view.SurfaceHolder;
 import android.view.SurfaceView;
+import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.InputConnection;
+import android.view.inputmethod.InputMethodManager;
 import android.widget.FrameLayout;
 
 import androidx.annotation.NonNull;
@@ -34,6 +38,7 @@ import androidx.annotation.Nullable;
 import androidx.annotation.UiThread;
 
 import org.wpewebkit.wpe.WPEEventType;
+import org.wpewebkit.wpe.WPEInputMethodContext;
 import org.wpewebkit.wpe.WPEToplevel;
 import org.wpewebkit.wpe.WPEView;
 import org.wpewebkit.wpe.WebKitWebView;
@@ -52,6 +57,10 @@ public class WebView extends FrameLayout {
     private WebKitWebView webKitWebView;
     private WPEToplevel wpeToplevel;
     WPEView platformView;
+    private WPEInputMethodContext imContext;
+    @Nullable
+    InputMethodManager inputMethodManager;
+    boolean inputFieldFocused;
     private PageSurfaceView surfaceView;
     private WebSettings webSettings;
     private @Nullable Surface attachedSurface;
@@ -85,6 +94,18 @@ public class WebView extends FrameLayout {
                                                wpeContext.getWebKitNetworkSession(), wpeContext.getWebKitSettings());
 
         this.platformView = webKitWebView.getWPEView();
+        this.imContext = webKitWebView.getInputMethodContext();
+        this.inputMethodManager = (InputMethodManager)getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
+        this.imContext.setFocusListener(new WPEInputMethodContext.FocusListener() {
+            @Override
+            public void onFocusIn() {
+                onImeFieldFocused(true);
+            }
+            @Override
+            public void onFocusOut() {
+                onImeFieldFocused(false);
+            }
+        });
         this.webSettings = new WebSettings(wpeContext.getWebKitSettings());
         this.wpeToplevel = new WPEToplevel(wpeContext.getWPEDisplay(), null);
         this.platformView.setToplevel(wpeToplevel);
@@ -311,6 +332,8 @@ public class WebView extends FrameLayout {
                 platformView.dispatchTouchEvent(
                     event.getEventTime(), type, 1, new int[] {event.getPointerId(actionIndex)},
                     new float[] {event.getX(actionIndex) / density}, new float[] {event.getY(actionIndex) / density});
+                if (action == MotionEvent.ACTION_UP && inputFieldFocused && inputMethodManager != null)
+                    inputMethodManager.showSoftInput(WebView.this, InputMethodManager.SHOW_IMPLICIT);
                 return true;
             case MotionEvent.ACTION_MOVE:
                 type = WPEEventType.TOUCH_MOVE;
@@ -335,6 +358,34 @@ public class WebView extends FrameLayout {
             platformView.dispatchTouchEvent(event.getEventTime(), type, pointerCount, ids, xs, ys);
             return true;
         }
+    }
+
+    void onImeFieldFocused(boolean focused) {
+        inputFieldFocused = focused;
+        if (inputMethodManager == null)
+            return;
+        if (focused) {
+            // restartInput refreshes EditorInfo (and re-invokes onCreateInputConnection) for the new field.
+            inputMethodManager.restartInput(this);
+            inputMethodManager.showSoftInput(this, InputMethodManager.SHOW_IMPLICIT);
+        } else if (getWindowToken() != null) {
+            inputMethodManager.hideSoftInputFromWindow(getWindowToken(), 0);
+        }
+    }
+
+    @Override
+    public InputConnection onCreateInputConnection(@NonNull EditorInfo outAttrs) {
+        if (!inputFieldFocused || imContext == null)
+            return null;
+        outAttrs.inputType = EditorInfo.TYPE_CLASS_TEXT | EditorInfo.TYPE_TEXT_VARIATION_WEB_EDIT_TEXT;
+        outAttrs.imeOptions = EditorInfo.IME_ACTION_NONE | EditorInfo.IME_FLAG_NO_FULLSCREEN;
+        outAttrs.actionLabel = null;
+        return new WPEInputConnection(this, /* fullEditor */ true, imContext);
+    }
+
+    @Override
+    public boolean onCheckIsTextEditor() {
+        return inputFieldFocused;
     }
 
     @Override


### PR DESCRIPTION
Adds the Android soft keyboard through the WPE Platform / CAPI / convenience layers so editable web elements (search boxes, forms) get a working on-screen keyboard. Hardware keys already worked after the recent refactor; this commit finishes the soft-IME support.

WPEInputMethodContextAndroid implements the focus_in/focus_out/reset vfuncs and exposes commit_text and delete_surrounding helpers. A new org.wpewebkit.wpe.WPEInputMethodContext borrowed-proxy bridges them to Java, and a BaseInputConnection adapter in
org.wpewebkit.wpeview.WPEInputConnection routes typed text (converted via g_utf16_to_utf8 so emoji survive the JNI boundary) and IME key events back. WebKitWebView owns the proxy's lifetime; WebView caches an InputMethodManager handle and shows or hides the soft keyboard on focus signals from WebKit, plus re-raises it on tap when the IME was dismissed externally.