### PR TITLE
Fix startup failure in VR devices

### DIFF
--- a/tools/minibrowser/src/main/java/org/wpewebkit/tools/minibrowser/MainActivity.kt
+++ b/tools/minibrowser/src/main/java/org/wpewebkit/tools/minibrowser/MainActivity.kt
@@ -32,12 +32,12 @@ import androidx.navigation.fragment.NavHostFragment
 import org.wpewebkit.tools.minibrowser.databinding.ActivityMainBinding
 
 
-class MainActivity : AppCompatActivity(R.layout.activity_main) {
+class MainActivity : AppCompatActivity() {
 
     private val TAG = "MiniBrowser"
 
     private val navHost by lazy {
-        supportFragmentManager.primaryNavigationFragment as NavHostFragment
+        supportFragmentManager.findFragmentById(R.id.nav_host_view) as NavHostFragment
     }
 
     private lateinit var binding: ActivityMainBinding
@@ -47,6 +47,7 @@ class MainActivity : AppCompatActivity(R.layout.activity_main) {
         Log.d(TAG, "onCreate")
         enableEdgeToEdge();
         binding = ActivityMainBinding.inflate(layoutInflater)
+        setContentView(binding.root)
     }
 
     override fun onConfigurationChanged(newConfig: Configuration) {


### PR DESCRIPTION
MiniBrowsing was failing to start with the following errors.
  at org.wpewebkit.wpe.WebKitWebView.nativeLoadUrl(Native method)
  at org.wpewebkit.wpe.WebKitWebView.loadUrl(WebKitWebView.java:60)
  at org.wpewebkit.wpeview.WebView.loadUrl(WebView.java:225)
  at org.wpewebkit.tools.minibrowser.Tab$Companion.newTab(Tab.kt:38)
  at org.wpewebkit.tools.minibrowser.BrowserFragment.onViewCreated(BrowserFragment.kt:110)
  at androidx.fragment.app.Fragment.performViewCreated(Fragment.java:3152)
  at androidx.fragment.app.FragmentStateManager.createView(FragmentStateManager.java:608)
  at androidx.fragment.app.FragmentStateManager.moveToExpectedState(FragmentStateManager.java:286)

The problem was in the Java part. The View binding was being inflated but never used with setContentView. Now the activity should properly use the binding. Apart from that this PR also replaces the navHost fragment lookup to use the ID from the layout.