### PR TITLE
Remove CMake dependency

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,6 @@ min-android-sdk = "31"
 target-android-sdk = "35"
 android-ndk = "27.0.12077973"
 android-sdk-build-tools = "35.0.0"
-cmake = "3.31.1"
 app-version-name = "1.0"
 app-version-code = "1"
 

--- a/wpeview/build.gradle
+++ b/wpeview/build.gradle
@@ -38,7 +38,6 @@ android {
 
     externalNativeBuild {
         cmake {
-            version = libs.versions.cmake.get()
             path file("src/main/cpp/CMakeLists.txt")
         }
     }


### PR DESCRIPTION
Setting a specific version makes initial setup more complex. It is also not really required for the android part, it is just needed in case of wanting to build the WPE library, but that is already handled by cerbero.