### PR TITLE
Enable the inspector server by default

### DIFF
--- a/wpeview/src/main/java/org/wpewebkit/WPEApplication.java
+++ b/wpeview/src/main/java/org/wpewebkit/WPEApplication.java
@@ -22,6 +22,7 @@ package org.wpewebkit;
 import android.app.Activity;
 import android.app.Application;
 import android.os.Bundle;
+import android.system.ErrnoException;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
@@ -83,6 +84,12 @@ public class WPEApplication extends Application {
     static {
         final String libraries[] = processKind.getLibraryNames();
         Log.d(LOGTAG, "Process: " + processKind.toString() + " - Libraries: " + String.join(", ", libraries));
+        String inspectorServer = "127.0.0.1:5000";
+        try {
+            android.system.Os.setenv("WEBKIT_INSPECTOR_SERVER", inspectorServer, false);
+        } catch (ErrnoException e) {
+            Log.e(LOGTAG, "Unable to setup the inspector server on " + inspectorServer);
+        }
         for (String libraryName : libraries)
             System.loadLibrary(libraryName);
     }

--- a/wpeview/src/main/java/org/wpewebkit/wpeview/WebContext.java
+++ b/wpeview/src/main/java/org/wpewebkit/wpeview/WebContext.java
@@ -71,6 +71,7 @@ public class WebContext {
         this.webKitCookieManager.setAcceptPolicy(WebKitCookieManager.WEBKIT_COOKIE_POLICY_ACCEPT_NO_THIRD_PARTY);
 
         this.settings = new WebKitSettings();
+        this.settings.setDeveloperExtrasEnabled(true);
     }
 
     /**


### PR DESCRIPTION
Enable the inspector server by default on port 5000. If there is an environment variable already defined, the MiniBrowser will use it instead. In order to enable the inspector server all the developer extras had to be enabled too.