### PR TITLE
MediaPlayer: Port to the new convenience API

### DIFF
--- a/tools/mediaplayer/build.gradle
+++ b/tools/mediaplayer/build.gradle
@@ -37,6 +37,7 @@ android {
 dependencies {
     implementation project(":wpeview")
     implementation libs.androidx.appcompat
+    runtimeOnly libs.openxr.loader
 
     modules {
         module("org.jetbrains.kotlin:kotlin-stdlib-jdk7") {

--- a/tools/mediaplayer/src/main/AndroidManifest.xml
+++ b/tools/mediaplayer/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:label="@string/app_name"
         android:theme="@style/Theme.AppCompat.NoActionBar">
+        <uses-native-library android:name="libopenxr_loader.so" android:required="false" />
         <activity
             android:name="org.wpewebkit.tools.mediaplayer.MainActivity"
             android:exported="true"

--- a/tools/mediaplayer/src/main/java/org/wpewebkit/tools/mediaplayer/MainActivity.java
+++ b/tools/mediaplayer/src/main/java/org/wpewebkit/tools/mediaplayer/MainActivity.java
@@ -32,7 +32,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 
-import org.wpewebkit.wpeview.WPEView;
+import org.wpewebkit.wpeview.WebView;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -62,10 +62,12 @@ public class MainActivity extends AppCompatActivity {
 
         try {
             String content = getHtmlContent();
-            WPEView view = findViewById(R.id.wpe_view);
+            WebView view = findViewById(R.id.wpe_view);
             view.getSettings().setAllowFileAccessFromFileURLs(true);
             view.getSettings().setAllowUniversalAccessFromFileURLs(true);
-            view.loadHtml(content, "file:///");
+            // baseUri needs an http(s) scheme: YouTube's embed postMessage
+            // handshake rejects null origins (error 153) so file:/// cannot be used.
+            view.loadHtml(content, "https://mediaplayer.local/");
         } catch (IOException ex) {
             String message = "Cannot initialize web application";
             Toast.makeText(this, message, Toast.LENGTH_LONG).show();

--- a/tools/mediaplayer/src/main/res/layout/main.xml
+++ b/tools/mediaplayer/src/main/res/layout/main.xml
@@ -3,7 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     tools:context="org.wpewebkit.tools.mediaplayer.MainActivity">
 
-    <org.wpewebkit.wpeview.WPEView
+    <org.wpewebkit.wpeview.WebView
         android:id="@+id/wpe_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"


### PR DESCRIPTION
Port the legacy org.wpewebkit.wpeview.WPEView widget for the new org.wpewebkit.wpeview.WebView in MainActivity.java and main.xml. The public API surface used by the demo (getSettings, setAllow*FromFileURLs, loadHtml) is preserved across the two classes, so no more changes needed.

Added the OpenXR loader needed now after including the XR support.

Also switch the baseUri passed to loadHtml from file:/// to https://mediaplayer.local/. The YouTube embed postMessage handshake refuses to initialize against a null origin and renders error 153 instead of the player.