### PR TITLE
Fix wrong assignment in bootstrap.py

### DIFF
--- a/tools/scripts/bootstrap.py
+++ b/tools/scripts/bootstrap.py
@@ -123,7 +123,7 @@ class Bootstrap:
             args = vars(args)
 
         self._arch = args["arch"] if "arch" in args else self.default_arch
-        self.default_version = args["version"] if "version" in args else self.default_version
+        self.version = args["version"] if "version" in args else self.default_version
         self._external_cerbero_build_path = args["cerbero"] if "cerbero" in args else None
         self._build = args["build"] if "build" in args else False
         self._debug = args["debug"] if "debug" in args else False
@@ -561,7 +561,7 @@ class Bootstrap:
             self.ensure_script_deps()
         except Exception as e:
             sys.exit(e)
-        version = self.default_version
+        version = self.version
         if self._external_cerbero_build_path:
             version = self.copy_all_packages_from_external_cerbero_build()
         elif self._build:


### PR DESCRIPTION
The constructor should assign self.version based on either the default value or the value passed by argument, and not self.default_version.

The only reason this works is because self.default_version is then read in the run() method, which is also a mistake, but the two mistakes at the same time is what makes this work.

To clean this up, we need to update both assignments.