### PR TITLE
WebDriver: Port to the new convenience API

### DIFF
--- a/tools/webdriver/build.gradle
+++ b/tools/webdriver/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     implementation libs.androidx.appcompat
     implementation libs.android.material
     implementation libs.androidx.constraintlayout
+    runtimeOnly libs.openxr.loader
 
     testImplementation libs.junit
     androidTestImplementation libs.androidx.test.junit

--- a/tools/webdriver/src/main/java/org/wpewebkit/tools/webdriver/WebDriverActivity.kt
+++ b/tools/webdriver/src/main/java/org/wpewebkit/tools/webdriver/WebDriverActivity.kt
@@ -30,9 +30,9 @@ import androidx.appcompat.app.AppCompatActivity
 import org.wpewebkit.wpe.WKProcessType
 import org.wpewebkit.wpe.services.WPEServiceConnection
 import org.wpewebkit.wpe.services.WPEServiceConnectionListener
-import org.wpewebkit.wpeview.WPEChromeClient
-import org.wpewebkit.wpeview.WPEContext
-import org.wpewebkit.wpeview.WPEView
+import org.wpewebkit.wpeview.WebChromeClient
+import org.wpewebkit.wpeview.WebContext
+import org.wpewebkit.wpeview.WebView
 import java.net.ServerSocket
 import kotlin.system.exitProcess
 
@@ -41,8 +41,8 @@ class WebDriverActivity : AppCompatActivity() {
 
     private val LOGTAG = "WebDriver"
 
-    private lateinit var wpeContext: WPEContext
-    private var wpeViewMap= mutableMapOf<Int, WPEView>()
+    private lateinit var webContext: WebContext
+    private val webViewMap = mutableMapOf<Int, WebView>()
     private var freePort = getFreePort()
     private var isHeadless = false
 
@@ -59,37 +59,24 @@ class WebDriverActivity : AppCompatActivity() {
         }
     }
 
-    private val wpeChromeClient: WPEChromeClient = object :
-        WPEChromeClient {
-        override fun onCloseWindow(wpeView: WPEView) {
-            wpeView.parent?.let {p ->
-                (p as ViewGroup).removeView(wpeView)
-            }
-
-            wpeViewMap.remove(wpeView.hashCode())
-            wpeView.destroy()
+    private val webChromeClient: WebChromeClient = object : WebChromeClient() {
+        override fun onCloseWindow(window: WebView) {
+            (window.parent as? ViewGroup)?.removeView(window)
+            webViewMap.remove(window.hashCode())
+            window.destroy()
         }
     }
 
-    private val wpeContextClient: WPEContext.Client  = object : WPEContext.Client {
-
-        override fun createWPEViewForAutomation(): WPEView? {
-            val wpeView = createWPEView()
-            wpeViewMap[wpeView.hashCode()] = wpeView
-            return wpeView
-        }
-
-        private fun createWPEView() : WPEView {
-            val view = WPEView(wpeContext, isHeadless)
-            view.wpeChromeClient = wpeChromeClient
-
+    private val webContextClient: WebContext.Client = WebContext.Client {
+        val view = WebView(webContext, isHeadless).apply {
+            setWebChromeClient(webChromeClient)
             if (!isHeadless) {
-                setContentView(view)
-                view.loadUrl("about:blank")
+                setContentView(this)
+                loadUrl("about:blank")
             }
-
-            return view
         }
+        webViewMap[view.hashCode()] = view
+        view
     }
 
     private fun getFreePort(): Int {
@@ -127,16 +114,25 @@ class WebDriverActivity : AppCompatActivity() {
             Log.e(LOGTAG, "Cannot launch webdriver process", e)
         }
 
-        WPEView.enableRemoteInspector(freePort, false)
+        WebContext.enableRemoteInspector(freePort, false)
 
-        wpeContext = WPEContext(applicationContext, true)
-        wpeContext.setClient(wpeContextClient)
+        webContext = WebContext(applicationContext, true)
+        webContext.setClient(webContextClient)
     }
 
     override fun onDestroy() {
-        for ((key, view) in wpeViewMap) {
-            view.destroy()
-            wpeViewMap.remove(key)
+        if (::webContext.isInitialized) {
+            webContext.setClient(null)
+        }
+
+        val iterator = webViewMap.values.iterator()
+        while (iterator.hasNext()) {
+            iterator.next().destroy()
+            iterator.remove()
+        }
+
+        if (::webContext.isInitialized) {
+            webContext.destroy()
         }
 
         super.onDestroy()

--- a/wpeview/src/main/java/org/wpewebkit/wpeview/WebContext.java
+++ b/wpeview/src/main/java/org/wpewebkit/wpeview/WebContext.java
@@ -23,6 +23,7 @@ import android.util.DisplayMetrics;
 import android.view.Display;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import org.wpewebkit.wpe.WKRuntime;
 import org.wpewebkit.wpe.WPEDisplay;
@@ -31,6 +32,7 @@ import org.wpewebkit.wpe.WebKitCookieManager;
 import org.wpewebkit.wpe.WebKitNetworkSession;
 import org.wpewebkit.wpe.WebKitSettings;
 import org.wpewebkit.wpe.WebKitWebContext;
+import org.wpewebkit.wpe.WebKitWebView;
 import org.wpewebkit.wpe.WebKitWebsiteDataManager;
 
 /**
@@ -38,6 +40,15 @@ import org.wpewebkit.wpe.WebKitWebsiteDataManager;
  * It manages the lifecycle of the display, web context, network session, cookies, and settings wrappers.
  */
 public class WebContext {
+    /**
+     * Embedder hook for automation sessions. The WebDriver/automation path calls
+     * {@link #createWebViewForAutomation()} when a remote client asks for a new browsing context.
+     */
+    public interface Client {
+        @Nullable
+        WebView createWebViewForAutomation();
+    }
+
     private final WPEDisplay display;
     private final WPEScreen screen;
     private final WebKitWebContext webContext;
@@ -84,6 +95,25 @@ public class WebContext {
     public static boolean shouldUseEphemeralSession() {
         return android.os.Build.PRODUCT.contains("sdk") || android.os.Build.PRODUCT.contains("vbox") ||
             android.os.Build.HARDWARE.contains("goldfish") || android.os.Build.HARDWARE.contains("ranchu");
+    }
+
+    /**
+     * Enable WebKit's remote inspector server. Must be called before any {@link WebContext} is created.
+     * Delegates to {@link WKRuntime#enableRemoteInspector(int, boolean)}.
+     */
+    public static void enableRemoteInspector(int inspectorPort, boolean useHttpInspector) {
+        WKRuntime.enableRemoteInspector(inspectorPort, useHttpInspector);
+    }
+
+    /**
+     * Register an automation {@link Client}. Only meaningful when this context was constructed with
+     * {@code automationMode=true}; the callback fires when WebDriver asks for a new browsing context.
+     */
+    public void setClient(@Nullable Client client) {
+        webContext.setClient(client == null ? null : () -> {
+            WebView view = client.createWebViewForAutomation();
+            return view != null ? view.getInternalWebKitWebView() : null;
+        });
     }
 
     public void destroy() {

--- a/wpeview/src/main/java/org/wpewebkit/wpeview/WebView.java
+++ b/wpeview/src/main/java/org/wpewebkit/wpeview/WebView.java
@@ -54,6 +54,7 @@ import java.util.Map;
 public class WebView extends FrameLayout {
     private WebContext wpeContext;
     private boolean ownsContext;
+    private boolean headless;
     private WebKitWebView webKitWebView;
     private WPEToplevel wpeToplevel;
     WPEView platformView;
@@ -78,17 +79,28 @@ public class WebView extends FrameLayout {
 
     public WebView(@NonNull android.content.Context context, @Nullable AttributeSet attrs) {
         super(context, attrs);
-        init(new WebContext(context), true);
+        init(new WebContext(context), true, false);
     }
 
     public WebView(@NonNull WebContext context) {
         super(context.getApplicationContext());
-        init(context, false);
+        init(context, false, false);
     }
 
-    private void init(@NonNull WebContext context, boolean ownsContext) {
+    /**
+     * Constructs a {@link WebView} without an on-screen Surface. JS, navigation and listeners
+     * still work; the view simply never gets a backing window so the compositor reports it as
+     * unmappable. Used by automation/WebDriver headless sessions.
+     */
+    public WebView(@NonNull WebContext context, boolean headless) {
+        super(context.getApplicationContext());
+        init(context, false, headless);
+    }
+
+    private void init(@NonNull WebContext context, boolean ownsContext, boolean headless) {
         this.wpeContext = context;
         this.ownsContext = ownsContext;
+        this.headless = headless;
 
         this.webKitWebView = new WebKitWebView(wpeContext.getWPEDisplay(), wpeContext.getWebKitWebContext(), null,
                                                wpeContext.getWebKitNetworkSession(), wpeContext.getWebKitSettings());
@@ -154,12 +166,19 @@ public class WebView extends FrameLayout {
             }
         });
 
-        this.surfaceView = new PageSurfaceView(getContext());
-        this.surfaceView.getHolder().addCallback(new SurfaceCallback());
-        addView(surfaceView);
+        if (!headless) {
+            this.surfaceView = new PageSurfaceView(getContext());
+            this.surfaceView.getHolder().addCallback(new SurfaceCallback());
+            addView(surfaceView);
+        }
 
         setFocusable(true);
         setFocusableInTouchMode(true);
+    }
+
+    @NonNull
+    WebKitWebView getInternalWebKitWebView() {
+        return webKitWebView;
     }
 
     public void destroy() {


### PR DESCRIPTION
Port tools/webdriver/ off WPEContext/WPEView and onto the new WebContext/WebView API. Add the supporting Layer-1 hooks needed by the automation flow:

- WebContext.Client + setClient() for the create-web-view callback; forwards to the underlying WebKitWebContext.Client.
- WebContext.enableRemoteInspector() static passthrough to WKRuntime.
- WebView(WebContext, boolean headless) ctor that skips the on-screen PageSurfaceView; the WPEToplevel never gets a Surface so WPEViewAndroid::can_be_mapped() returns false while JS/DOM still work.

Add the missing libopenxr_loader runtime dependency that broke first launch (matches tools/minibrowser/).

WebDriverActivity.onDestroy() now clears the automation client and destroys the WebContext so the JNI GlobalRef in
capi/WebKitWebContext.cpp releases the bridge.