### PR TITLE
Convenience API: Add JavaScript dialog override support

### DIFF
--- a/tools/minibrowser/src/main/java/org/wpewebkit/tools/minibrowser/BrowserFragment.kt
+++ b/tools/minibrowser/src/main/java/org/wpewebkit/tools/minibrowser/BrowserFragment.kt
@@ -107,7 +107,7 @@ class BrowserFragment : Fragment(R.layout.fragment_browser) {
             binding.toolbarEditText.setText(tab.webview.url)
         } ?: run {
             val app = requireContext().applicationContext as MiniBrowserApplication
-            val tab = Tab.newTab(app.browserContext, INITIAL_URL)
+            val tab = Tab.newTab(requireContext(), app.browserContext, INITIAL_URL)
             browserViewModel.addTab(tab)
             binding.tabContainerView.addView(tab.webview)
             binding.toolbarEditText.setText(tab.webview.url)

--- a/tools/minibrowser/src/main/java/org/wpewebkit/tools/minibrowser/Tab.kt
+++ b/tools/minibrowser/src/main/java/org/wpewebkit/tools/minibrowser/Tab.kt
@@ -19,6 +19,7 @@
 
 package org.wpewebkit.tools.minibrowser
 
+import android.content.Context
 import org.wpewebkit.wpeview.WebView
 import org.wpewebkit.wpeview.WebContext as BrowserContext
 import java.util.UUID
@@ -29,12 +30,14 @@ data class Tab(
 ) {
     companion object {
         fun newTab(
+            uiContext: Context,
             browserContext: BrowserContext,
             url: String
         ) : Tab {
             return Tab(
                 UUID.randomUUID().toString(),
-                WebView(browserContext).apply {
+                // Use the Activity context so the WebView can show JS dialogs / the soft keyboard.
+                WebView(uiContext, browserContext).apply {
                     loadUrl(url)
                 }
             )

--- a/wpeview/src/main/cpp/capi/WebKitWebView.cpp
+++ b/wpeview/src/main/cpp/capi/WebKitWebView.cpp
@@ -90,6 +90,7 @@ public:
         , m_onEstimatedLoadProgress(getMethod<void(jdouble)>("onEstimatedLoadProgress"))
         , m_onTitleChanged(getMethod<void(jstring, jboolean, jboolean)>("onTitleChanged"))
         , m_onReceivedHttpError(getMethod<void(jstring, jstring, jstring, jint)>("onReceivedHttpError"))
+        , m_onScriptDialog(getMethod<void(jlong, jint, jstring, jstring, jstring)>("onScriptDialog"))
     {
         registerNativeMethods(JNI::NativeMethod<jlong(jlong, jlong, jlong, jlong, jlong)>("nativeInit", nativeInit),
             JNI::NativeMethod<void(jlong)>("nativeDestroy", nativeDestroy),
@@ -103,7 +104,9 @@ public:
             JNI::NativeMethod<jlong(jlong)>("nativeGetWPEView", nativeGetWPEView),
             JNI::NativeMethod<void(jlong, jdouble)>("nativeSetZoomLevel", nativeSetZoomLevel),
             JNI::NativeMethod<void(jlong, jstring, JNIWebKitWebViewEvalCallbackHolder)>(
-                "nativeEvaluateJavascript", nativeEvaluateJavascript));
+                "nativeEvaluateJavascript", nativeEvaluateJavascript),
+            JNI::NativeMethod<void(jlong, jboolean, jstring)>("nativeScriptDialogConfirm", nativeScriptDialogConfirm),
+            JNI::NativeMethod<void(jlong)>("nativeScriptDialogClose", nativeScriptDialogClose));
     }
 
     const JNI::Method<void()> m_onClose;
@@ -113,6 +116,7 @@ public:
     const JNI::Method<void(jdouble)> m_onEstimatedLoadProgress;
     const JNI::Method<void(jstring, jboolean, jboolean)> m_onTitleChanged;
     const JNI::Method<void(jstring, jstring, jstring, jint)> m_onReceivedHttpError;
+    const JNI::Method<void(jlong, jint, jstring, jstring, jstring)> m_onScriptDialog;
 
 private:
     static void onClose(WebKitWebView*, WebKitWebViewBridge* bridge);
@@ -122,6 +126,7 @@ private:
     static void onTitleChanged(GObject* obj, GParamSpec*, WebKitWebViewBridge* bridge);
     static gboolean onDecidePolicy(WebKitWebView*, WebKitPolicyDecision* decision,
         WebKitPolicyDecisionType decisionType, WebKitWebViewBridge* bridge);
+    static gboolean onScriptDialog(WebKitWebView* webView, WebKitScriptDialog* dialog, WebKitWebViewBridge* bridge);
     static void onEvalJavascriptReady(GObject* object, GAsyncResult* result, gpointer userData);
 
     static jlong nativeInit(JNIEnv* env, jobject jniWebView, jlong displayPtr, jlong contextPtr, jlong toplevelPtr,
@@ -138,6 +143,8 @@ private:
     static void nativeSetZoomLevel(JNIEnv*, jobject, jlong nativePtr, jdouble zoomLevel);
     static void nativeEvaluateJavascript(
         JNIEnv* env, jobject, jlong nativePtr, jstring script, JNIWebKitWebViewEvalCallbackHolder callbackHolder);
+    static void nativeScriptDialogConfirm(JNIEnv*, jobject, jlong dialogPtr, jboolean confirm, jstring text);
+    static void nativeScriptDialogClose(JNIEnv*, jobject, jlong dialogPtr);
 };
 
 const JNIWebKitWebViewCache& getJNIWebKitWebViewCache()
@@ -236,6 +243,32 @@ gboolean JNIWebKitWebViewCache::onDecidePolicy(
     return FALSE;
 }
 
+gboolean JNIWebKitWebViewCache::onScriptDialog(
+    WebKitWebView* webView, WebKitScriptDialog* dialog, WebKitWebViewBridge* bridge)
+{
+    // Keep the dialog alive across the asynchronous round-trip to Java; it is released by
+    // nativeScriptDialogClose once the embedder (or the default dialog) has answered.
+    auto dialogPtr = reinterpret_cast<jlong>(webkit_script_dialog_ref(dialog));
+    WebKitScriptDialogType type = webkit_script_dialog_get_dialog_type(dialog);
+    // The active URI is null before the first commit and the message may be null; pass them through
+    // as null (JNI::String(nullptr) yields a null jstring) — the Java callbacks treat null as "no value".
+    auto jUrl = JNI::String(webkit_web_view_get_uri(webView));
+    auto jMessage = JNI::String(webkit_script_dialog_get_message(dialog));
+    JNI::String jDefaultText = type == WEBKIT_SCRIPT_DIALOG_PROMPT
+        ? JNI::String(webkit_script_dialog_prompt_get_default_text(dialog))
+        : JNI::String("");
+    try {
+        getJNIWebKitWebViewCache().m_onScriptDialog.invoke(bridge->m_javaRef.get(), dialogPtr, static_cast<jint>(type),
+            static_cast<jstring>(jUrl), static_cast<jstring>(jMessage), static_cast<jstring>(jDefaultText));
+    } catch (const std::exception& ex) {
+        Logging::logError("cannot deliver WebKitWebView onScriptDialog callback (%s)", ex.what());
+        webkit_script_dialog_unref(dialog);
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
 void JNIWebKitWebViewCache::onEvalJavascriptReady(GObject* object, GAsyncResult* result, gpointer userData)
 {
     std::unique_ptr<JNI::GlobalRef<JNIWebKitWebViewEvalCallbackHolder>> holder(
@@ -292,6 +325,7 @@ jlong JNIWebKitWebViewCache::nativeInit(JNIEnv* env, jobject jniWebView, jlong d
         g_signal_connect(webView, "notify::estimated-load-progress", G_CALLBACK(onEstimatedLoadProgress), bridge),
         g_signal_connect(webView, "notify::title", G_CALLBACK(onTitleChanged), bridge),
         g_signal_connect(webView, "notify::uri", G_CALLBACK(onUriChanged), bridge),
+        g_signal_connect(webView, "script-dialog", G_CALLBACK(onScriptDialog), bridge),
     };
 
     return reinterpret_cast<jlong>(bridge);
@@ -358,6 +392,20 @@ void JNIWebKitWebViewCache::nativeEvaluateJavascript(
         = callbackHolder ? new JNI::GlobalRef<JNIWebKitWebViewEvalCallbackHolder>(env, callbackHolder) : nullptr;
     webkit_web_view_evaluate_javascript(bridge->m_webView, JNI::String(script).getContent().get(), -1, nullptr, nullptr,
         nullptr, holder ? onEvalJavascriptReady : nullptr, holder);
+}
+
+void JNIWebKitWebViewCache::nativeScriptDialogConfirm(JNIEnv*, jobject, jlong dialogPtr, jboolean confirm, jstring text)
+{
+    auto* dialog = reinterpret_cast<WebKitScriptDialog*>(dialogPtr); // NOLINT(performance-no-int-to-ptr)
+    if (webkit_script_dialog_get_dialog_type(dialog) == WEBKIT_SCRIPT_DIALOG_PROMPT && text != nullptr)
+        webkit_script_dialog_prompt_set_text(dialog, JNI::String(text).getContent().get());
+    webkit_script_dialog_confirm_set_confirmed(dialog, static_cast<gboolean>(confirm));
+}
+
+void JNIWebKitWebViewCache::nativeScriptDialogClose(JNIEnv*, jobject, jlong dialogPtr)
+{
+    // Releases the reference taken in onScriptDialog; the dialog is closed once its refcount reaches zero.
+    webkit_script_dialog_unref(reinterpret_cast<WebKitScriptDialog*>(dialogPtr)); // NOLINT(performance-no-int-to-ptr)
 }
 
 void configureWebKitWebViewJNIMappings()

--- a/wpeview/src/main/java/org/wpewebkit/wpe/WebKitWebView.java
+++ b/wpeview/src/main/java/org/wpewebkit/wpe/WebKitWebView.java
@@ -26,6 +26,12 @@ import androidx.annotation.Nullable;
  * WebKitWebView is an owning JNI proxy for a native WebKitWebView object.
  */
 public final class WebKitWebView {
+    // Mirrors WebKitScriptDialogType.
+    public static final int SCRIPT_DIALOG_ALERT = 0;
+    public static final int SCRIPT_DIALOG_CONFIRM = 1;
+    public static final int SCRIPT_DIALOG_PROMPT = 2;
+    public static final int SCRIPT_DIALOG_BEFORE_UNLOAD_CONFIRM = 3;
+
     private long mNativePtr = 0;
     private final WPEView wpeView;
     private final WPEInputMethodContext inputMethodContext;
@@ -126,6 +132,8 @@ public final class WebKitWebView {
         void onLoadProgress(double progress);
         void onTitleChanged(@NonNull String title, boolean canGoBack, boolean canGoForward);
         void onReceivedHttpError(@NonNull String uri, @NonNull String method, @NonNull String mimeType, int statusCode);
+        void onScriptDialog(long dialogPtr, int type, @Nullable String url, @Nullable String message,
+                            @NonNull String defaultText);
     }
 
     private @Nullable Listener listener;
@@ -181,6 +189,26 @@ public final class WebKitWebView {
             MainLooperDispatcher.post(() -> currentListener.onReceivedHttpError(uri, method, mimeType, statusCode));
     }
 
+    @Keep
+    private void onScriptDialog(long dialogPtr, int type, String url, String message, String defaultText) {
+        Listener currentListener = listener;
+        if (currentListener != null)
+            MainLooperDispatcher.post(() -> currentListener.onScriptDialog(dialogPtr, type, url, message, defaultText));
+        else
+            nativeScriptDialogClose(dialogPtr);
+    }
+
+    /**
+     * Answers a script dialog reported via {@link Listener#onScriptDialog}. Must be paired with
+     *  {@link #scriptDialogClose}. For prompts, {@code text} carries the user's input.
+     */
+    public void scriptDialogConfirm(long dialogPtr, boolean confirm, @Nullable String text) {
+        nativeScriptDialogConfirm(dialogPtr, confirm, text);
+    }
+
+    /** Releases the native script dialog reported via {@link Listener#onScriptDialog}. */
+    public void scriptDialogClose(long dialogPtr) { nativeScriptDialogClose(dialogPtr); }
+
     private static class EvalCallbackHolder {
         private final EvalCallback callback;
 
@@ -206,4 +234,6 @@ public final class WebKitWebView {
     private native void nativeSetZoomLevel(long nativePtr, double zoomLevel);
     private native void nativeEvaluateJavascript(long nativePtr, String script,
                                                  @Nullable EvalCallbackHolder callbackHolder);
+    private native void nativeScriptDialogConfirm(long dialogPtr, boolean confirm, @Nullable String text);
+    private native void nativeScriptDialogClose(long dialogPtr);
 }

--- a/wpeview/src/main/java/org/wpewebkit/wpeview/WPEJsPromptResult.java
+++ b/wpeview/src/main/java/org/wpewebkit/wpeview/WPEJsPromptResult.java
@@ -3,10 +3,10 @@ package org.wpewebkit.wpeview;
 import androidx.annotation.NonNull;
 
 /**
- * Interface for handling JavaScript prompt requests. The WPEChromeClient will receive a
- * {@link WPEChromeClient#onJsPrompt(WPEView, String, String, String, WPEJsPromptResult)} call with a
+ * Interface for handling JavaScript prompt requests. The WebChromeClient will receive a
+ * {@link WebChromeClient#onJsPrompt(WebView, String, String, String, WPEJsPromptResult)} call with a
  * WPEJsPromptResult instance as a parameter. This parameter is used to return the result of this user
- * dialog prompt back to the WPEView instance. The client can call cancel() to cancel the dialog or
+ * dialog prompt back to the WebView instance. The client can call cancel() to cancel the dialog or
  * confirm() with the user's input to confirm the dialog.
  */
 public interface WPEJsPromptResult extends WPEJsResult {

--- a/wpeview/src/main/java/org/wpewebkit/wpeview/WPEJsResult.java
+++ b/wpeview/src/main/java/org/wpewebkit/wpeview/WPEJsResult.java
@@ -1,7 +1,7 @@
 package org.wpewebkit.wpeview;
 
 /**
- * An instance of this interface implementation is passed as a parameter in various {@link WPEChromeClient} action
+ * An instance of this interface implementation is passed as a parameter in various {@link WebChromeClient} action
  * notifications. The object is used as a handle onto the underlying JavaScript-originated request,
  * and provides a means for the client to indicate whether this action should proceed.
  */

--- a/wpeview/src/main/java/org/wpewebkit/wpeview/WebChromeClient.java
+++ b/wpeview/src/main/java/org/wpewebkit/wpeview/WebChromeClient.java
@@ -21,6 +21,7 @@ package org.wpewebkit.wpeview;
 import android.view.View;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 /**
  * WebChromeClient provides the high-level chrome and UI callbacks for {@link WebView}.
@@ -37,4 +38,43 @@ public class WebChromeClient {
     // FIXME: wire WebKit enter-fullscreen / leave-fullscreen signals to invoke these callbacks.
     public void onShowCustomView(@NonNull View view, @NonNull CustomViewCallback callback) {}
     public void onHideCustomView() {}
+
+    /**
+     * Notifies the host of a JavaScript {@code alert()}. Return {@code true} to take over the
+     * dialog (calling {@link WPEJsResult#confirm()} when done); return {@code false} to let
+     * {@link WebView} show its built-in dialog.
+     */
+    public boolean onJsAlert(@NonNull WebView view, @Nullable String url, @Nullable String message,
+                             @NonNull WPEJsResult result) {
+        return false;
+    }
+
+    /**
+     * Notifies the host of a JavaScript {@code confirm()}. Return {@code true} to take over the
+     * dialog (calling {@link WPEJsResult#confirm()} or {@link WPEJsResult#cancel()}); return
+     * {@code false} for the built-in dialog.
+     */
+    public boolean onJsConfirm(@NonNull WebView view, @Nullable String url, @Nullable String message,
+                               @NonNull WPEJsResult result) {
+        return false;
+    }
+
+    /**
+     * Notifies the host of a JavaScript {@code prompt()}. Return {@code true} to take over the
+     * dialog (calling {@link WPEJsPromptResult#confirm(String)} or {@link WPEJsResult#cancel()});
+     * return {@code false} for the built-in dialog.
+     */
+    public boolean onJsPrompt(@NonNull WebView view, @Nullable String url, @Nullable String message,
+                              @NonNull String defaultValue, @NonNull WPEJsPromptResult result) {
+        return false;
+    }
+
+    /**
+     * Notifies the host of a JavaScript {@code beforeunload} confirmation. Return {@code true} to
+     * take over the dialog; return {@code false} for the built-in dialog.
+     */
+    public boolean onJsBeforeUnload(@NonNull WebView view, @Nullable String url, @Nullable String message,
+                                    @NonNull WPEJsResult result) {
+        return false;
+    }
 }

--- a/wpeview/src/main/java/org/wpewebkit/wpeview/WebView.java
+++ b/wpeview/src/main/java/org/wpewebkit/wpeview/WebView.java
@@ -19,30 +19,39 @@
 package org.wpewebkit.wpeview;
 
 import android.annotation.SuppressLint;
+import android.app.AlertDialog;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.graphics.Color;
 import android.net.Uri;
 import android.util.AttributeSet;
 import android.view.KeyEvent;
+import android.view.LayoutInflater;
 import android.view.MotionEvent;
 import android.view.Surface;
 import android.view.SurfaceHolder;
 import android.view.SurfaceView;
+import android.view.View;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
 import android.view.inputmethod.InputMethodManager;
+import android.widget.EditText;
 import android.widget.FrameLayout;
+import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.UiThread;
 
+import org.wpewebkit.R;
 import org.wpewebkit.wpe.WPEEventType;
 import org.wpewebkit.wpe.WPEInputMethodContext;
 import org.wpewebkit.wpe.WPEToplevel;
 import org.wpewebkit.wpe.WPEView;
 import org.wpewebkit.wpe.WebKitWebView;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.Collections;
 import java.util.Map;
 
@@ -55,7 +64,8 @@ public class WebView extends FrameLayout {
     private WebContext wpeContext;
     private boolean ownsContext;
     private boolean headless;
-    private WebKitWebView webKitWebView;
+    // Package-private: read by the ScriptDialogResult inner class (avoids a synthetic accessor).
+    WebKitWebView webKitWebView;
     private WPEToplevel wpeToplevel;
     WPEView platformView;
     private WPEInputMethodContext imContext;
@@ -84,6 +94,17 @@ public class WebView extends FrameLayout {
 
     public WebView(@NonNull WebContext context) {
         super(context.getApplicationContext());
+        init(context, false, false);
+    }
+
+    /**
+     * Constructs a {@link WebView} that renders with {@code uiContext} while sharing the given
+     * {@link WebContext}. Pass an Activity context (not the application context): it is required to
+     * show the built-in JavaScript dialogs and the soft keyboard, mirroring
+     * {@code android.webkit.WebView}.
+     */
+    public WebView(@NonNull android.content.Context uiContext, @NonNull WebContext context) {
+        super(uiContext);
         init(context, false, false);
     }
 
@@ -163,6 +184,11 @@ public class WebView extends FrameLayout {
                 WPEResourceRequest request = new HttpResourceRequest(Uri.parse(uri), method);
                 WPEResourceResponse response = new WPEResourceResponse(mimeType, statusCode, Collections.emptyMap());
                 viewClient.onReceivedHttpError(WebView.this, request, response);
+            }
+
+            @Override
+            public void onScriptDialog(long dialogPtr, int type, String url, String message, String defaultText) {
+                showScriptDialog(dialogPtr, type, url, message, defaultText);
             }
         });
 
@@ -291,6 +317,129 @@ public class WebView extends FrameLayout {
     }
 
     public void setTLSErrorsPolicy(int policy) { wpeContext.getWebKitNetworkSession().setTLSErrorsPolicy(policy); }
+
+    // Package-private: called from the WebKitWebView.Listener inner class (avoids a synthetic accessor).
+    void showScriptDialog(long dialogPtr, int type, @Nullable String url, @Nullable String message,
+                          @NonNull String defaultText) {
+        ScriptDialogResult result = new ScriptDialogResult(dialogPtr);
+        boolean handled = false;
+        if (type == WebKitWebView.SCRIPT_DIALOG_ALERT) {
+            handled = chromeClient.onJsAlert(this, url, message, result);
+        } else if (type == WebKitWebView.SCRIPT_DIALOG_CONFIRM) {
+            handled = chromeClient.onJsConfirm(this, url, message, result);
+        } else if (type == WebKitWebView.SCRIPT_DIALOG_PROMPT) {
+            handled = chromeClient.onJsPrompt(this, url, message, defaultText, result);
+        } else if (type == WebKitWebView.SCRIPT_DIALOG_BEFORE_UNLOAD_CONFIRM) {
+            handled = chromeClient.onJsBeforeUnload(this, url, message, result);
+        }
+        if (handled)
+            return;
+
+        String title = url;
+        String displayMessage = message;
+        int positiveTextId = R.string.ok;
+        int negativeTextId = R.string.cancel;
+        if (type == WebKitWebView.SCRIPT_DIALOG_BEFORE_UNLOAD_CONFIRM) {
+            title = getContext().getString(R.string.js_dialog_before_unload_title);
+            displayMessage = getContext().getString(R.string.js_dialog_before_unload, message);
+            positiveTextId = R.string.js_dialog_before_unload_positive_button;
+            negativeTextId = R.string.js_dialog_before_unload_negative_button;
+        } else if (url != null) {
+            try {
+                URL alertUrl = new URL(url);
+                title = "The page at " + alertUrl.getProtocol() + "://" + alertUrl.getHost() + " says";
+            } catch (MalformedURLException ex) {
+                // Keep the raw URL as the title.
+            }
+        }
+
+        final AlertDialog.Builder builder = new AlertDialog.Builder(getContext());
+        builder.setTitle(title);
+        builder.setOnCancelListener(new ScriptDialogCancelListener(result));
+        if (type != WebKitWebView.SCRIPT_DIALOG_PROMPT) {
+            builder.setMessage(displayMessage);
+            builder.setPositiveButton(positiveTextId, new ScriptDialogPositiveListener(result, null));
+        } else {
+            @SuppressLint("InflateParams")
+            final View view = LayoutInflater.from(getContext()).inflate(R.layout.js_prompt, null);
+            EditText edit = view.findViewById(R.id.value);
+            edit.setText(defaultText);
+            builder.setPositiveButton(positiveTextId, new ScriptDialogPositiveListener(result, edit));
+            ((TextView)view.findViewById(R.id.message)).setText(message);
+            builder.setView(view);
+        }
+        if (type != WebKitWebView.SCRIPT_DIALOG_ALERT) {
+            builder.setNegativeButton(negativeTextId, new ScriptDialogCancelListener(result));
+        }
+        builder.show();
+    }
+
+    private class ScriptDialogResult implements WPEJsPromptResult {
+        private final long dialogPtr;
+        private @Nullable String stringResult;
+
+        ScriptDialogResult(long dialogPtr) { this.dialogPtr = dialogPtr; }
+
+        @Override
+        public void cancel() {
+            // webKitWebView is null once the view has been destroyed; the dialog is torn down with
+            // the page in that case, so there is nothing to answer.
+            if (webKitWebView != null) {
+                webKitWebView.scriptDialogConfirm(dialogPtr, false, stringResult);
+                webKitWebView.scriptDialogClose(dialogPtr);
+            }
+        }
+
+        @Override
+        public void confirm() {
+            if (webKitWebView != null) {
+                webKitWebView.scriptDialogConfirm(dialogPtr, true, stringResult);
+                webKitWebView.scriptDialogClose(dialogPtr);
+            }
+        }
+
+        @Override
+        public void confirm(@NonNull String result) {
+            stringResult = result;
+            confirm();
+        }
+    }
+
+    private static class ScriptDialogCancelListener
+        implements DialogInterface.OnCancelListener, DialogInterface.OnClickListener {
+        private final WPEJsResult result;
+
+        ScriptDialogCancelListener(@NonNull WPEJsResult result) { this.result = result; }
+
+        @Override
+        public void onCancel(DialogInterface dialog) {
+            result.cancel();
+        }
+
+        @Override
+        public void onClick(DialogInterface dialog, int which) {
+            result.cancel();
+        }
+    }
+
+    private static class ScriptDialogPositiveListener implements DialogInterface.OnClickListener {
+        private final WPEJsPromptResult result;
+        private final @Nullable EditText edit;
+
+        ScriptDialogPositiveListener(@NonNull WPEJsPromptResult result, @Nullable EditText edit) {
+            this.result = result;
+            this.edit = edit;
+        }
+
+        @Override
+        public void onClick(DialogInterface dialog, int which) {
+            if (edit != null) {
+                result.confirm(edit.getText().toString());
+            } else {
+                result.confirm();
+            }
+        }
+    }
 
     private static class HttpResourceRequest implements WPEResourceRequest {
         private final Uri uri;


### PR DESCRIPTION
Add WebKit's script-dialog signal into the convenience API so embedders can intercept alert/confirm/prompt/beforeunload dialogs, with a dialog as the default.

- capi/WebKitWebView.cpp: connect the script-dialog signal, send the dialog type/URL/message/default-text to Java, and add nativeScriptDialogConfirm/Close to answer the dialog asynchronously.
- WebKitWebView.java: dialog-type constants, Listener.onScriptDialog upcall and scriptDialogConfirm/scriptDialogClose.
- WebChromeClient: onJsAlert/onJsConfirm/onJsPrompt/onJsBeforeUnload (default to the built-in dialog), reusing WPEJsResult/WPEJsPromptResult.
- WebView: deliver dialogs to the WebChromeClient and fall back to an AlertDialog; add WebView(Context, WebContext) so a shared WebContext can be paired with an Activity context (required for the dialogs and soft keyboard to attach to a window).
- MiniBrowser: create tabs with the Activity context via that constructor, this is required for testing.