### PR TITLE
Stop the UIProcess main thread busy-spinning at 100% CPU

### DIFF
--- a/wpeview/src/main/cpp/Runtime/MessagePump.cpp
+++ b/wpeview/src/main/cpp/Runtime/MessagePump.cpp
@@ -183,8 +183,7 @@ void MessagePump::prepare() noexcept
 
     for (const auto& pollFD : changedPollFDs) {
         ALooper_addFd(
-            m_looper, pollFD.fd, ALOOPER_POLL_CALLBACK,
-            static_cast<int>(glibEventsToLooperEvents(pollFD.events) | ALOOPER_EVENT_OUTPUT),
+            m_looper, pollFD.fd, ALOOPER_POLL_CALLBACK, static_cast<int>(glibEventsToLooperEvents(pollFD.events)),
             +[](int fileDesc, int events, void* userData) -> int {
                 auto* pump = reinterpret_cast<MessagePump*>(userData);
                 for (int j = 0; j < pump->m_pollFdsSize; ++j) {


### PR DESCRIPTION
MessagePump registered every GLib poll fd with the Android looper using an unconditional ALOOPER_EVENT_OUTPUT on top of the events GLib actually requested. ALOOPER_EVENT_OUTPUT maps to EPOLLOUT and the looper's epoll is level-triggered, so fds that are almost always writable (the GLib wakeup eventfd, the IPC read sockets, etc.) reported ready on every epoll_wait. The looper callback re-called a GLib dispatch each time, which woke the loop again, so ALooper_pollOnce never blocked: the UIProcess main thread spun at ~100% CPU continuously, on every page, even while completely idle.

Register each fd only for the events GLib asked for via glibEventsToLooperEvents(pollFD.events). This still requests ALOOPER_EVENT_OUTPUT for sources that genuinely poll for G_IO_OUT, but no longer forces it onto read-only fds. Idle UIProcess main-thread CPU drops from ~100% to 0% (measured on an arm64 Pixel 7 and the x86_64 emulator); rendering, animation and scrolling are unaffected.

