### PR TITLE
wpewebkit: Update to version 2.53.3.1

### DIFF
--- a/tools/scripts/bootstrap.py
+++ b/tools/scripts/bootstrap.py
@@ -81,7 +81,7 @@ from urllib.request import urlretrieve
 
 class Bootstrap:
     default_arch = "arm64"
-    default_version = "2.53.3"
+    default_version = "2.53.3.1"
 
     _cerbero_origin = "https://github.com/Igalia/wpe-android-cerbero.git"
     _cerbero_branch = "main"


### PR DESCRIPTION
Bump the bootstrap default version so devs fetch the 2.53.3.1 package (WebKit 5a62df plus the scrolling-race fix from upstream PR #67062).