### PR TITLE
Bump to wpewebkit 2.53.3.3 and rely on Skia DDL default

### DIFF
--- a/tools/scripts/bootstrap.py
+++ b/tools/scripts/bootstrap.py
@@ -81,7 +81,7 @@ from urllib.request import urlretrieve
 
 class Bootstrap:
     default_arch = "arm64"
-    default_version = "2.53.3.2"
+    default_version = "2.53.3.3"
 
     _cerbero_origin = "https://github.com/Igalia/wpe-android-cerbero.git"
     _cerbero_branch = "main"

--- a/wpeview/src/main/java/org/wpewebkit/wpe/services/WebProcessService.java
+++ b/wpeview/src/main/java/org/wpewebkit/wpe/services/WebProcessService.java
@@ -118,9 +118,6 @@ public class WebProcessService extends WPEService {
         envStrings.add("WEBKIT_INSPECTOR_RESOURCES_PATH");
         envStrings.add(new File(context.getFilesDir(), "injected-bundles").getAbsolutePath());
 
-        envStrings.add("WEBKIT_SKIA_ENABLE_DDL");
-        envStrings.add("1");
-
         if ((appInfo.flags & ApplicationInfo.FLAG_DEBUGGABLE) == ApplicationInfo.FLAG_DEBUGGABLE) {
             String gstDebugLevels = "*:FIXME";
 


### PR DESCRIPTION
Drop the WEBKIT_SKIA_ENABLE_DDL=1 WebProcess environment variable: at 60a8b5a SkiaPaintingEngine::isDDLEnabled() defaults to true.