### PR TITLE
Bump to wpewebkit 2.53.3.6

### DIFF
--- a/tools/scripts/bootstrap.py
+++ b/tools/scripts/bootstrap.py
@@ -26,7 +26,7 @@
 
 """
 This script takes care of fetching, building and installing all WPE Android dependencies,
-including libwpe and WPEWebKit.
+including WPEWebKit.
 
 The cross-compilation work is done by Cerbero: https://github.com/Igalia/wpe-android-cerbero.git
 
@@ -81,7 +81,7 @@ from urllib.request import urlretrieve
 
 class Bootstrap:
     default_arch = "arm64"
-    default_version = "2.53.3.5"
+    default_version = "2.53.3.6"
 
     _cerbero_origin = "https://github.com/Igalia/wpe-android-cerbero.git"
     _cerbero_branch = "main"
@@ -98,7 +98,6 @@ class Bootstrap:
         "libglib-2.0.so",
         "libgmodule-2.0.so",
         "libgobject-2.0.so",
-        "libwpe-1.0.so",
         "libWPEWebKit-2.0.so",
         "libopenxr_loader.so"
     ]
@@ -106,7 +105,6 @@ class Bootstrap:
         ("glib-2.0", "glib-2.0"),
         ("gstreamer-1.0", "gstreamer-1.0"),
         ("libsoup-3.0", "libsoup-3.0"),
-        ("wpe-1.0", "wpe"),
         ("wpe-webkit-2.0", "wpe-webkit"),
         ("xkbcommon", "xkbcommon")
     ]

--- a/wpeview/src/main/cpp/CMakeLists.txt
+++ b/wpeview/src/main/cpp/CMakeLists.txt
@@ -83,11 +83,6 @@ set_target_properties(
         "${CMAKE_SOURCE_DIR}/imported/include;${CMAKE_SOURCE_DIR}/imported/include/wpe-webkit;${CMAKE_SOURCE_DIR}/imported/include/wpe-webkit/wpe-platform;${CMAKE_SOURCE_DIR}/imported/include/libsoup-3.0"
 )
 
-add_library(libwpe-1.0 SHARED IMPORTED)
-set_target_properties(
-    libwpe-1.0 PROPERTIES IMPORTED_LOCATION "${CMAKE_SOURCE_DIR}/imported/lib/${ANDROID_ABI}/libwpe-1.0.so"
-                          INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_SOURCE_DIR}/imported/include/wpe")
-
 add_library(WPEWebDriver SHARED IMPORTED)
 set_target_properties(WPEWebDriver PROPERTIES IMPORTED_LOCATION
                                               "${CMAKE_SOURCE_DIR}/imported/lib/${ANDROID_ABI}/libWPEWebDriver.so")
@@ -109,7 +104,6 @@ target_link_libraries(
     glib-2.0
     gobject-2.0
     gstreamer-1.0
-    libwpe-1.0
     WPEWebKit-2.0)
 
 # libWPEAndroidRuntime
@@ -118,6 +112,7 @@ add_library(
     Platform/WPEDisplayAndroid.cpp
     Platform/WPEInputMethodContextAndroid.cpp
     Platform/WPEKeymapAndroid.cpp
+    Platform/WPEProcessManagerAndroid.cpp
     Platform/WPEScreenAndroid.cpp
     Platform/WPEScreenSyncObserverAndroid.cpp
     Platform/WPEToplevelAndroid.cpp
@@ -148,7 +143,6 @@ target_link_libraries(
     gio-2.0
     glib-2.0
     gobject-2.0
-    libwpe-1.0
     soup-3.0
     WPEWebKit-2.0
     WPEAndroidCommon)

--- a/wpeview/src/main/cpp/Platform/WPEDisplayAndroid.cpp
+++ b/wpeview/src/main/cpp/Platform/WPEDisplayAndroid.cpp
@@ -21,6 +21,7 @@
 #include "Logging.h"
 #include "WPEInputMethodContextAndroid.h"
 #include "WPEKeymapAndroid.h"
+#include "WPEProcessManagerAndroid.h"
 #include "WPEScreenAndroid.h"
 #include "WPEToplevelAndroid.h"
 #include "WPEViewAndroid.h"
@@ -86,6 +87,13 @@ static gboolean wpeDisplayAndroidConnect(WPEDisplay* display, GError** error)
     displayAndroid->eglDisplay = eglDisplay;
     displayAndroid->keymap = wpe_keymap_android_new();
     displayAndroid->screen = wpe_screen_android_new();
+
+    if (!wpe_process_manager_get_default()) {
+        WPEProcessManager* processManager = wpe_process_manager_android_new();
+        wpe_process_manager_set_default(processManager);
+        g_object_unref(processManager);
+    }
+
     return TRUE;
 }
 

--- a/wpeview/src/main/cpp/Platform/WPEProcessManagerAndroid.cpp
+++ b/wpeview/src/main/cpp/Platform/WPEProcessManagerAndroid.cpp
@@ -1,0 +1,86 @@
+/**
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include "WPEProcessManagerAndroid.h"
+
+#include "Environment.h"
+#include "Logging.h"
+#include "WKRuntime.h"
+
+#include <unistd.h>
+
+struct _WPEProcessManagerAndroid {
+    WPEProcessManager parentInstance;
+};
+
+G_DEFINE_FINAL_TYPE(WPEProcessManagerAndroid, wpe_process_manager_android, WPE_TYPE_PROCESS_MANAGER)
+
+static guint64 wpeProcessManagerAndroidLaunch(WPEProcessManager*, WPEProcessLaunchOptions* options, GError** error)
+{
+    auto wpeProcessType = wpe_process_launch_options_get_process_type(options);
+    auto processId = wpe_process_launch_options_get_process_id(options);
+    auto ipcSocketFD = wpe_process_launch_options_get_ipc_socket_fd(options);
+
+    Logging::logDebug("WPEProcessManagerAndroid::launch(type=%d, pid=%" G_GUINT64_FORMAT ", fd=%d) [tid %d]",
+        wpeProcessType, processId, ipcSocketFD, gettid());
+
+    auto processType = ProcessType::TypesCount;
+    if (wpeProcessType == WPE_PROCESS_TYPE_WEB) {
+        processType = ProcessType::WebProcess;
+        Logging::logVerbose("Launching WebProcess");
+    } else if (wpeProcessType == WPE_PROCESS_TYPE_NETWORK) {
+        processType = ProcessType::NetworkProcess;
+        Logging::logVerbose("Launching NetworkProcess");
+    }
+
+    if ((processType < ProcessType::FirstType) || (processType >= ProcessType::TypesCount)) {
+        g_set_error(error, WPE_PROCESS_MANAGER_ERROR, WPE_PROCESS_MANAGER_ERROR_LAUNCH_FAILED,
+            "Cannot launch process (invalid process type: %d)", static_cast<int>(wpeProcessType));
+        return 0;
+    }
+
+    if (!wkRuntimeLaunchProcess(static_cast<int64_t>(processId), static_cast<int>(processType), ipcSocketFD)) {
+        g_set_error(error, WPE_PROCESS_MANAGER_ERROR, WPE_PROCESS_MANAGER_ERROR_LAUNCH_FAILED,
+            "Failed to launch process (type: %d)", static_cast<int>(processType));
+        return 0;
+    }
+
+    return processId;
+}
+
+static void wpeProcessManagerAndroidTerminate(WPEProcessManager*, guint64 pid)
+{
+    Logging::logDebug("WPEProcessManagerAndroid::terminate(%" G_GUINT64_FORMAT ") [tid %d]", pid, gettid());
+    wkRuntimeTerminateProcess(static_cast<int64_t>(pid));
+}
+
+static void wpe_process_manager_android_init(WPEProcessManagerAndroid*)
+{
+}
+
+static void wpe_process_manager_android_class_init(WPEProcessManagerAndroidClass* klass)
+{
+    auto* managerClass = WPE_PROCESS_MANAGER_CLASS(klass);
+    managerClass->launch = wpeProcessManagerAndroidLaunch;
+    managerClass->terminate = wpeProcessManagerAndroidTerminate;
+}
+
+WPEProcessManager* wpe_process_manager_android_new(void)
+{
+    return WPE_PROCESS_MANAGER(g_object_new(WPE_TYPE_PROCESS_MANAGER_ANDROID, nullptr));
+}

--- a/wpeview/src/main/cpp/Platform/WPEProcessManagerAndroid.h
+++ b/wpeview/src/main/cpp/Platform/WPEProcessManagerAndroid.h
@@ -1,0 +1,32 @@
+/**
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#pragma once
+
+#include <glib-object.h>
+#include <wpe/wpe-platform.h>
+
+G_BEGIN_DECLS
+
+#define WPE_TYPE_PROCESS_MANAGER_ANDROID (wpe_process_manager_android_get_type())
+G_DECLARE_FINAL_TYPE(
+    WPEProcessManagerAndroid, wpe_process_manager_android, WPE, PROCESS_MANAGER_ANDROID, WPEProcessManager)
+
+WPEProcessManager* wpe_process_manager_android_new(void);
+
+G_END_DECLS

--- a/wpeview/src/main/cpp/Runtime/WKRuntime.cpp
+++ b/wpeview/src/main/cpp/Runtime/WKRuntime.cpp
@@ -106,44 +106,19 @@ JNIBrowserCache::JNIBrowserCache()
             }));
 }
 
-namespace {
 /***********************************************************************************************************************
- * WPE process provider functions
+ * Process launch/terminate bridge to the Java WKRuntime (used by WPEProcessManagerAndroid)
  **********************************************************************************************************************/
 
-int64_t wpeLaunchProcess(void* /*backend*/, wpe_process_type wpeProcessType, void* userData) noexcept
+bool wkRuntimeLaunchProcess(int64_t processId, int processType, int ipcSocketFd) noexcept
 {
-    Logging::logDebug("wpeLaunchProcess(%d, %p) [tid %d]", wpeProcessType, userData, gettid());
-    auto** options = reinterpret_cast<char**>(userData);
-    if ((options == nullptr) || (options[0] == nullptr) || (options[1] == nullptr))
-        return -1;
-
-    const jlong pid = std::strtoll(options[0], nullptr, 10); // NOLINT(cppcoreguidelines-avoid-magic-numbers)
-    const jint fileDesc = std::stoi(options[1]);
-
-    auto processType = ProcessType::TypesCount;
-    if (wpeProcessType == WPE_PROCESS_TYPE_WEB) {
-        processType = ProcessType::WebProcess;
-        Logging::logVerbose("Launching WebProcess");
-    } else if (wpeProcessType == WPE_PROCESS_TYPE_NETWORK) {
-        processType = ProcessType::NetworkProcess;
-        Logging::logVerbose("Launching NetworkProcess");
-    }
-
-    if ((processType < ProcessType::FirstType) || (processType >= ProcessType::TypesCount)) {
-        Logging::logError("Cannot launch process (invalid process type: %d)", static_cast<int>(processType));
-        return -1;
-    }
-
-    return getJNIBrowserCache().launchProcess(pid, static_cast<jint>(processType), fileDesc) ? 0 : -1;
+    return getJNIBrowserCache().launchProcess(processId, processType, ipcSocketFd);
 }
 
-void wpeTerminateProcess(void* /*backend*/, int64_t pid)
+void wkRuntimeTerminateProcess(int64_t processId) noexcept
 {
-    Logging::logDebug("wpeTerminateProcess(%ld) [tid %d]", pid, gettid());
-    getJNIBrowserCache().terminateProcess(pid);
+    getJNIBrowserCache().terminateProcess(processId);
 }
-} // namespace
 
 WKRuntime::WKRuntime()
 {
@@ -154,17 +129,6 @@ WKRuntime::WKRuntime()
 void WKRuntime::configureJNIMappings()
 {
     getJNIBrowserCache();
-
-    static const wpe_process_provider_interface s_processProviderInterface = {.create = nullptr,
-        .destroy = nullptr,
-        .launch = wpeLaunchProcess,
-        .terminate = wpeTerminateProcess,
-        ._wpe_reserved1 = nullptr,
-        ._wpe_reserved2 = nullptr,
-        ._wpe_reserved3 = nullptr,
-        ._wpe_reserved4 = nullptr,
-        ._wpe_reserved5 = nullptr};
-    wpe_process_provider_register_interface(&s_processProviderInterface);
 }
 
 void WKRuntime::jniInit()

--- a/wpeview/src/main/cpp/Runtime/WKRuntime.h
+++ b/wpeview/src/main/cpp/Runtime/WKRuntime.h
@@ -24,6 +24,13 @@
 
 #include "MessagePump.h"
 
+#include <cstdint>
+
+// Bridges to the Java WKRuntime for launching/terminating WebKit auxiliary processes as Android
+// services. Used by WPEProcessManagerAndroid. processType is a Common/Environment.h ProcessType value.
+bool wkRuntimeLaunchProcess(int64_t processId, int processType, int ipcSocketFd) noexcept;
+void wkRuntimeTerminateProcess(int64_t processId) noexcept;
+
 class WKRuntime final {
 public:
     static void configureJNIMappings();


### PR DESCRIPTION
Bump the prebuilt wpewebkit to 2.53.3.6 and remove the libwpe dependency: add WPEProcessManagerAndroid to launch WebKit's auxiliary processes via the upstream WPEProcessManager (registered as the default in WPEDisplayAndroid), wire the launch/terminate bridge through WKRuntime, and drop libwpe from the imported libs/includes.
