### PR TITLE
wpeview: Fold the WKRuntime singleton into the JNI cache

### DIFF
--- a/wpeview/src/main/cpp/Runtime/WKRuntime.cpp
+++ b/wpeview/src/main/cpp/Runtime/WKRuntime.cpp
@@ -24,8 +24,10 @@
 
 #include "Environment.h"
 #include "Logging.h"
+#include "MessagePump.h"
 
-#include <wpe/webkit.h>
+#include <memory>
+#include <unistd.h>
 
 /***********************************************************************************************************************
  * JNI mapping with Java WKRuntime class
@@ -59,6 +61,9 @@ public:
 
 private:
     mutable JNI::ProtectedType<JNIWPERuntime> m_runtimeJavaInstance;
+    // The MessagePump attaching the GLib main context to the Android main looper, alive between
+    // the Java WKRuntime nativeInit() and nativeShut() calls.
+    mutable std::unique_ptr<MessagePump> m_messagePump;
 
     // NOLINTBEGIN(cppcoreguidelines-avoid-const-or-ref-data-members)
     const JNI::Method<void(jlong, jint, jint)> m_launchProcessMethod;
@@ -87,14 +92,18 @@ JNIWPERuntimeCache::JNIWPERuntimeCache()
         JNI::NativeMethod<void()>(
             "nativeInit",
             +[](JNIEnv* env, jobject obj) {
-                getJNIWPERuntimeCache().m_runtimeJavaInstance
+                Logging::logDebug("WKRuntime::nativeInit() [tid %d]", gettid());
+                const auto& cache = getJNIWPERuntimeCache();
+                cache.m_runtimeJavaInstance
                     = JNI::createTypedProtectedRef(env, reinterpret_cast<JNIWPERuntime>(obj), true);
-                WKRuntime::instance().jniInit();
+                cache.m_messagePump = std::make_unique<MessagePump>();
             }),
         JNI::NativeMethod<void()>(
             "nativeShut", +[](JNIEnv*, jobject) {
-                WKRuntime::instance().jniShut();
-                getJNIWPERuntimeCache().m_runtimeJavaInstance = nullptr;
+                Logging::logDebug("WKRuntime::nativeShut() [tid %d]", gettid());
+                const auto& cache = getJNIWPERuntimeCache();
+                cache.m_messagePump = nullptr;
+                cache.m_runtimeJavaInstance = nullptr;
             }));
 }
 
@@ -112,29 +121,7 @@ void wkRuntimeTerminateProcess(int64_t processId) noexcept
     getJNIWPERuntimeCache().terminateProcess(processId);
 }
 
-WKRuntime::WKRuntime()
-{
-    Logging::logDebug("WKRuntime [tid %d], WPE WebKit %u.%u.%u", gettid(), webkit_get_major_version(),
-        webkit_get_minor_version(), webkit_get_micro_version());
-}
-
 void WKRuntime::configureJNIMappings()
 {
     getJNIWPERuntimeCache();
-}
-
-void WKRuntime::jniInit()
-{
-    Logging::logDebug("WKRuntime::jniInit() [tid %d]", gettid());
-    m_messagePump = std::make_unique<MessagePump>();
-}
-
-void WKRuntime::jniShut() noexcept
-{
-    try {
-        Logging::logDebug("WKRuntime::jniShut() [tid %d]", gettid());
-        m_messagePump = nullptr;
-        // TODO NOLINTNEXTLINE(bugprone-empty-catch)
-    } catch (...) {
-    }
 }

--- a/wpeview/src/main/cpp/Runtime/WKRuntime.h
+++ b/wpeview/src/main/cpp/Runtime/WKRuntime.h
@@ -22,8 +22,6 @@
 
 #pragma once
 
-#include "MessagePump.h"
-
 #include <cstdint>
 
 // Bridges to the Java WKRuntime for launching/terminating WebKit auxiliary processes as Android
@@ -31,29 +29,6 @@
 bool wkRuntimeLaunchProcess(int64_t processId, int processType, int ipcSocketFd) noexcept;
 void wkRuntimeTerminateProcess(int64_t processId) noexcept;
 
-class WKRuntime final {
-public:
-    static void configureJNIMappings();
-
-    static WKRuntime& instance() noexcept
-    {
-        static WKRuntime s_singleton;
-        return s_singleton;
-    }
-
-    WKRuntime(WKRuntime&&) = delete;
-    WKRuntime& operator=(WKRuntime&&) = delete;
-    WKRuntime(const WKRuntime&) = delete;
-    WKRuntime& operator=(const WKRuntime&) = delete;
-
-    ~WKRuntime() { jniShut(); }
-
-private:
-    WKRuntime();
-
-    friend class JNIWPERuntimeCache;
-    void jniInit();
-    void jniShut() noexcept;
-
-    std::unique_ptr<MessagePump> m_messagePump {};
-};
+namespace WKRuntime {
+void configureJNIMappings();
+} // namespace WKRuntime


### PR DESCRIPTION
After the dead code removal, the WKRuntime class only owned the MessagePump between the Java nativeInit() and nativeShut() calls. Move the pump into JNIWPERuntimeCache, which already holds the Java instance reference with the same lifetime, and reduce the header to the process launch/terminate bridge plus a configureJNIMappings() function. This     also stops leaking MessagePump.h (and its GLib and looper headers) into WPEProcessManagerAndroid.
