### PR TITLE
wpeview: Rename the WK-prefixed infrastructure classes to WPE

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,21 +21,20 @@ the Android services used for auxiliary processes.
 Java code lives in:
 
 - `wpeview/src/main/java/org/wpewebkit/WPEApplication.java`
-- `wpeview/src/main/java/org/wpewebkit/wpe/WKRuntime.java`
-- `wpeview/src/main/java/org/wpewebkit/wpe/WKActivityObserver.java`
+- `wpeview/src/main/java/org/wpewebkit/wpe/WPERuntime.java`
+- `wpeview/src/main/java/org/wpewebkit/wpe/WPEActivityObserver.java`
 - `wpeview/src/main/java/org/wpewebkit/wpe/AuxiliaryProcessesContainer.java`
 - `wpeview/src/main/java/org/wpewebkit/wpe/services/`
 
 Native code lives in:
 
 - `wpeview/src/main/cpp/Runtime/EntryPoint.cpp`
-- `wpeview/src/main/cpp/Runtime/WKRuntime.cpp`
+- `wpeview/src/main/cpp/Runtime/WPERuntime.cpp`
 - `wpeview/src/main/cpp/Runtime/MessagePump.cpp`
-- `wpeview/src/main/cpp/Runtime/LooperThread.cpp`
 - `wpeview/src/main/cpp/Common/`
 
 `Runtime/EntryPoint.cpp` is the JNI entry point. It initializes the common JNI
-environment, registers the `WKRuntime` infrastructure JNI mappings, then
+environment, registers the `WPERuntime` infrastructure JNI mappings, then
 registers the `capi/` mappings through `WebKit::configureJNIMappings()`.
 
 ### Layer 1: Public Android convenience API
@@ -249,9 +248,8 @@ Add Android platform behavior to Layer 3:
 Add runtime or process behavior to Layer 0:
 
 - Put JNI startup and mapping registration in `Runtime/EntryPoint.cpp`.
-- Put process-provider changes in `Runtime/WKRuntime.cpp`.
-- Put looper and GLib main-loop integration in `Runtime/MessagePump.cpp` or
-  `Runtime/LooperThread.cpp`.
+- Put process-provider changes in `Runtime/WPERuntime.cpp`.
+- Put looper and GLib main-loop integration in `Runtime/MessagePump.cpp`.
 - Put service-side code under `org.wpewebkit.wpe.services` and
   `wpeview/src/main/cpp/Service/`.
 
@@ -290,6 +288,7 @@ The legacy convenience and proxy classes (`org.wpewebkit.wpeview.WPEView`,
 (`WebView`, `WebContext`, `WebSettings`, …) and the `WebKit`/`WPE` CAPI proxies
 instead.
 
-Runtime names such as `WKRuntime`, `WKActivityObserver`, and `WKProcessType` are
-still part of the infrastructure layer and are not replaced by the public API
-naming split yet.
+The infrastructure layer classes formerly using the `WK` prefix have been
+renamed: `WPERuntime`, `WPEActivityObserver`, `WPEProcessType`, and
+`WPEVersions`. Note these are Android infrastructure names, not proxies of
+WPEPlatform C types.

--- a/tools/webdriver/src/main/java/org/wpewebkit/tools/webdriver/WebDriverActivity.kt
+++ b/tools/webdriver/src/main/java/org/wpewebkit/tools/webdriver/WebDriverActivity.kt
@@ -27,7 +27,7 @@ import android.os.ParcelFileDescriptor
 import android.util.Log
 import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
-import org.wpewebkit.wpe.WKProcessType
+import org.wpewebkit.wpe.WPEProcessType
 import org.wpewebkit.wpe.services.WPEServiceConnection
 import org.wpewebkit.wpe.services.WPEServiceConnectionListener
 import org.wpewebkit.wpeview.WebChromeClient
@@ -96,7 +96,7 @@ class WebDriverActivity : AppCompatActivity() {
         }
 
         try {
-            val processType = WKProcessType.WebDriverProcess
+            val processType = WPEProcessType.WebDriverProcess
             val serviceClass =
                 Class.forName("org.wpewebkit.wpe.services." + processType.name + "Service")
             val parcelFd = ParcelFileDescriptor.fromFd(0)

--- a/wpeview/src/main/cpp/CMakeLists.txt
+++ b/wpeview/src/main/cpp/CMakeLists.txt
@@ -119,7 +119,7 @@ add_library(
     Platform/WPEViewAndroid.cpp
     Runtime/EntryPoint.cpp
     Runtime/MessagePump.cpp
-    Runtime/WKRuntime.cpp
+    Runtime/WPERuntime.cpp
     capi/JNIMappings.cpp
     capi/WebKitCookieManager.cpp
     capi/WebKitNetworkSession.cpp

--- a/wpeview/src/main/cpp/Common/Init.cpp
+++ b/wpeview/src/main/cpp/Common/Init.cpp
@@ -22,9 +22,9 @@
 #include <gst/gst.h>
 #include <wpe/webkit.h>
 
-static void initializeWKVersions()
+static void initializeWPEVersions()
 {
-    auto klass = JNI::Class("org/wpewebkit/wpe/WKVersions");
+    auto klass = JNI::Class("org/wpewebkit/wpe/WPEVersions");
     g_autofree char* webkitVersion = g_strdup_printf(
         "%u.%u.%u", webkit_get_major_version(), webkit_get_minor_version(), webkit_get_micro_version());
 
@@ -52,7 +52,7 @@ static void initializeWKVersions()
     // TODO NOLINTNEXTLINE(bugprone-narrowing-conversions, cppcoreguidelines-narrowing-conversions)
     klass.getStaticField<jint>("GSTREAMER_NANO").setValue(gstNano);
 
-    Logging::logVerbose("WKRuntime::Init: WPE WebKit %s, GStreamer %s", webkitVersion, gstVersion);
+    Logging::logVerbose("Init: WPE WebKit %s, GStreamer %s", webkitVersion, gstVersion);
 }
 
 DECLARE_JNI_CLASS_SIGNATURE(JNIActivity, "android/app/Activity");
@@ -78,11 +78,11 @@ extern "C" __attribute__((visibility("default"))) jobject wpe_android_runtime_ge
     return s_applicationContext;
 }
 
-static void initializeWKActivityObserver()
+static void initializeWPEActivityObserver()
 {
-    auto klass = JNI::Class("org/wpewebkit/wpe/WKActivityObserver");
+    auto klass = JNI::Class("org/wpewebkit/wpe/WPEActivityObserver");
     if (!klass) {
-        Logging::logDebug("Init::initializeWKActivityObserver: No observer class, skipping.");
+        Logging::logDebug("Init::initializeWPEActivityObserver: No observer class, skipping.");
         return;
     }
 
@@ -90,7 +90,7 @@ static void initializeWKActivityObserver()
         JNI::StaticNativeMethod<void(JNIActivity)>(
             "handleActivityStarted",
             +[](JNIEnv* env, jclass, JNIActivity activity) {
-                Logging::logDebug("WKActivityObserver::handleActivityStarted(%p) current=%p [tid %d]", activity,
+                Logging::logDebug("WPEActivityObserver::handleActivityStarted(%p) current=%p [tid %d]", activity,
                     s_currentActivity, gettid());
                 if (s_currentActivity != nullptr)
                     env->DeleteGlobalRef(s_currentActivity);
@@ -98,7 +98,7 @@ static void initializeWKActivityObserver()
             }),
         JNI::StaticNativeMethod<void(JNIActivity)>(
             "handleActivityStopped", +[](JNIEnv* env, jclass, JNIActivity activity) {
-                Logging::logDebug("WKActivityObserver::handleActivityStopped(%p) current=%p [tid %d]", activity,
+                Logging::logDebug("WPEActivityObserver::handleActivityStopped(%p) current=%p [tid %d]", activity,
                     s_currentActivity, gettid());
                 if (s_currentActivity != nullptr)
                     env->DeleteGlobalRef(s_currentActivity);
@@ -106,17 +106,17 @@ static void initializeWKActivityObserver()
             }));
 }
 
-static void initializeWKRuntime()
+static void initializeWPERuntime()
 {
-    auto klass = JNI::Class("org/wpewebkit/wpe/WKRuntime");
+    auto klass = JNI::Class("org/wpewebkit/wpe/WPERuntime");
     if (!klass) {
-        Logging::logDebug("Init::initializeWKRuntime: No runtime class, skipping.");
+        Logging::logDebug("Init::initializeWPERuntime: No runtime class, skipping.");
         return;
     }
 
     klass.registerNativeMethods(JNI::StaticNativeMethod<void(JNIContext)>(
         "setApplicationContext", +[](JNIEnv* env, jclass, JNIContext context) {
-            Logging::logDebug("WKRuntime::setApplicationContext(%p) [tid %d]", context, gettid());
+            Logging::logDebug("WPERuntime::setApplicationContext(%p) [tid %d]", context, gettid());
             if (s_applicationContext != nullptr)
                 env->DeleteGlobalRef(s_applicationContext);
             s_applicationContext = context ? static_cast<jobject>(env->NewGlobalRef(context)) : nullptr;
@@ -126,8 +126,8 @@ static void initializeWKRuntime()
 JNIEnv* Init::initialize(JavaVM* javaVM)
 {
     auto* env = JNI::initVM(javaVM);
-    initializeWKVersions();
-    initializeWKActivityObserver();
-    initializeWKRuntime();
+    initializeWPEVersions();
+    initializeWPEActivityObserver();
+    initializeWPERuntime();
     return env;
 }

--- a/wpeview/src/main/cpp/Platform/WPEProcessManagerAndroid.cpp
+++ b/wpeview/src/main/cpp/Platform/WPEProcessManagerAndroid.cpp
@@ -20,7 +20,7 @@
 
 #include "Environment.h"
 #include "Logging.h"
-#include "WKRuntime.h"
+#include "WPERuntime.h"
 
 #include <unistd.h>
 
@@ -54,7 +54,7 @@ static guint64 wpeProcessManagerAndroidLaunch(WPEProcessManager*, WPEProcessLaun
         return 0;
     }
 
-    if (!wkRuntimeLaunchProcess(static_cast<int64_t>(processId), static_cast<int>(processType), ipcSocketFD)) {
+    if (!wpeRuntimeLaunchProcess(static_cast<int64_t>(processId), static_cast<int>(processType), ipcSocketFD)) {
         g_set_error(error, WPE_PROCESS_MANAGER_ERROR, WPE_PROCESS_MANAGER_ERROR_LAUNCH_FAILED,
             "Failed to launch process (type: %d)", static_cast<int>(processType));
         return 0;
@@ -64,12 +64,12 @@ static guint64 wpeProcessManagerAndroidLaunch(WPEProcessManager*, WPEProcessLaun
 }
 
 // FIXME: when Android decides to kill a Service on its own (observed Java-side in
-// WKRuntime's onServiceDisconnected), WebKit is not notified and will not respawn
+// WPERuntime's onServiceDisconnected), WebKit is not notified and will not respawn
 // the auxiliary process until it needs it again.
 static void wpeProcessManagerAndroidTerminate(WPEProcessManager*, guint64 pid)
 {
     Logging::logDebug("WPEProcessManagerAndroid::terminate(%" G_GUINT64_FORMAT ") [tid %d]", pid, gettid());
-    wkRuntimeTerminateProcess(static_cast<int64_t>(pid));
+    wpeRuntimeTerminateProcess(static_cast<int64_t>(pid));
 }
 
 static void wpe_process_manager_android_init(WPEProcessManagerAndroid*)

--- a/wpeview/src/main/cpp/Runtime/EntryPoint.cpp
+++ b/wpeview/src/main/cpp/Runtime/EntryPoint.cpp
@@ -20,14 +20,14 @@
 #include "../capi/JNIMappings.h"
 #include "Init.h"
 #include "Logging.h"
-#include "WKRuntime.h"
+#include "WPERuntime.h"
 
 extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* javaVM, void* /*reserved*/)
 {
     try {
         Init::initialize(javaVM);
 
-        WKRuntime::configureJNIMappings();
+        WPERuntime::configureJNIMappings();
 
         WebKit::configureJNIMappings();
 

--- a/wpeview/src/main/cpp/Runtime/WPERuntime.cpp
+++ b/wpeview/src/main/cpp/Runtime/WPERuntime.cpp
@@ -20,7 +20,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#include "WKRuntime.h"
+#include "WPERuntime.h"
 
 #include "Environment.h"
 #include "Logging.h"
@@ -30,10 +30,10 @@
 #include <unistd.h>
 
 /***********************************************************************************************************************
- * JNI mapping with Java WKRuntime class
+ * JNI mapping with Java WPERuntime class
  **********************************************************************************************************************/
 
-DECLARE_JNI_CLASS_SIGNATURE(JNIWPERuntime, "org/wpewebkit/wpe/WKRuntime");
+DECLARE_JNI_CLASS_SIGNATURE(JNIWPERuntime, "org/wpewebkit/wpe/WPERuntime");
 
 class JNIWPERuntimeCache final : public JNI::TypedClass<JNIWPERuntime> {
 public:
@@ -62,7 +62,7 @@ public:
 private:
     mutable JNI::ProtectedType<JNIWPERuntime> m_runtimeJavaInstance;
     // The MessagePump attaching the GLib main context to the Android main looper, alive between
-    // the Java WKRuntime nativeInit() and nativeShut() calls.
+    // the Java WPERuntime nativeInit() and nativeShut() calls.
     mutable std::unique_ptr<MessagePump> m_messagePump;
 
     // NOLINTBEGIN(cppcoreguidelines-avoid-const-or-ref-data-members)
@@ -85,14 +85,14 @@ JNIWPERuntimeCache::JNIWPERuntimeCache()
     registerNativeMethods(JNI::StaticNativeMethod<void(jstringArray)>(
                               "setupNativeEnvironment",
                               +[](JNIEnv* /*env*/, jclass /*klass*/, jstringArray envStringsArray) {
-                                  Logging::logDebug("WKRuntime::setupNativeEnvironment() [tid %d]", gettid());
+                                  Logging::logDebug("WPERuntime::setupNativeEnvironment() [tid %d]", gettid());
                                   Logging::pipeStdoutToLogcat();
                                   Environment::configureEnvironment(envStringsArray);
                               }),
         JNI::NativeMethod<void()>(
             "nativeInit",
             +[](JNIEnv* env, jobject obj) {
-                Logging::logDebug("WKRuntime::nativeInit() [tid %d]", gettid());
+                Logging::logDebug("WPERuntime::nativeInit() [tid %d]", gettid());
                 const auto& cache = getJNIWPERuntimeCache();
                 cache.m_runtimeJavaInstance
                     = JNI::createTypedProtectedRef(env, reinterpret_cast<JNIWPERuntime>(obj), true);
@@ -100,7 +100,7 @@ JNIWPERuntimeCache::JNIWPERuntimeCache()
             }),
         JNI::NativeMethod<void()>(
             "nativeShut", +[](JNIEnv*, jobject) {
-                Logging::logDebug("WKRuntime::nativeShut() [tid %d]", gettid());
+                Logging::logDebug("WPERuntime::nativeShut() [tid %d]", gettid());
                 const auto& cache = getJNIWPERuntimeCache();
                 cache.m_messagePump = nullptr;
                 cache.m_runtimeJavaInstance = nullptr;
@@ -108,20 +108,20 @@ JNIWPERuntimeCache::JNIWPERuntimeCache()
 }
 
 /***********************************************************************************************************************
- * Process launch/terminate bridge to the Java WKRuntime (used by WPEProcessManagerAndroid)
+ * Process launch/terminate bridge to the Java WPERuntime (used by WPEProcessManagerAndroid)
  **********************************************************************************************************************/
 
-bool wkRuntimeLaunchProcess(int64_t processId, int processType, int ipcSocketFd) noexcept
+bool wpeRuntimeLaunchProcess(int64_t processId, int processType, int ipcSocketFd) noexcept
 {
     return getJNIWPERuntimeCache().launchProcess(processId, processType, ipcSocketFd);
 }
 
-void wkRuntimeTerminateProcess(int64_t processId) noexcept
+void wpeRuntimeTerminateProcess(int64_t processId) noexcept
 {
     getJNIWPERuntimeCache().terminateProcess(processId);
 }
 
-void WKRuntime::configureJNIMappings()
+void WPERuntime::configureJNIMappings()
 {
     getJNIWPERuntimeCache();
 }

--- a/wpeview/src/main/cpp/Runtime/WPERuntime.h
+++ b/wpeview/src/main/cpp/Runtime/WPERuntime.h
@@ -24,11 +24,11 @@
 
 #include <cstdint>
 
-// Bridges to the Java WKRuntime for launching/terminating WebKit auxiliary processes as Android
+// Bridges to the Java WPERuntime for launching/terminating WebKit auxiliary processes as Android
 // services. Used by WPEProcessManagerAndroid. processType is a Common/Environment.h ProcessType value.
-bool wkRuntimeLaunchProcess(int64_t processId, int processType, int ipcSocketFd) noexcept;
-void wkRuntimeTerminateProcess(int64_t processId) noexcept;
+bool wpeRuntimeLaunchProcess(int64_t processId, int processType, int ipcSocketFd) noexcept;
+void wpeRuntimeTerminateProcess(int64_t processId) noexcept;
 
-namespace WKRuntime {
+namespace WPERuntime {
 void configureJNIMappings();
-} // namespace WKRuntime
+} // namespace WPERuntime

--- a/wpeview/src/main/java/org/wpewebkit/WPEApplication.java
+++ b/wpeview/src/main/java/org/wpewebkit/WPEApplication.java
@@ -90,6 +90,6 @@ public class WPEApplication extends Application {
     public WPEApplication() {
         super();
         if (processKind == ProcessKind.MAIN)
-            registerActivityLifecycleCallbacks(new org.wpewebkit.wpe.WKActivityObserver());
+            registerActivityLifecycleCallbacks(new org.wpewebkit.wpe.WPEActivityObserver());
     }
 }

--- a/wpeview/src/main/java/org/wpewebkit/wpe/AuxiliaryProcessesContainer.java
+++ b/wpeview/src/main/java/org/wpewebkit/wpe/AuxiliaryProcessesContainer.java
@@ -30,11 +30,11 @@ final class AuxiliaryProcessesContainer {
     private static final int MAX_AUX_PROCESSES = org.wpewebkit.wpe.services.WPEServices.MAX_AUX_PROCESSES;
 
     private final AuxiliaryProcess[][] processes =
-        new AuxiliaryProcess[WKProcessType.values().length][MAX_AUX_PROCESSES];
+        new AuxiliaryProcess[WPEProcessType.values().length][MAX_AUX_PROCESSES];
     private final Map<Long, AuxiliaryProcess> pidToProcessMap = new HashMap<>();
-    private final int[] firstAvailableSlot = new int[WKProcessType.values().length];
+    private final int[] firstAvailableSlot = new int[WPEProcessType.values().length];
 
-    public int getFirstAvailableSlot(@NonNull WKProcessType processType) {
+    public int getFirstAvailableSlot(@NonNull WPEProcessType processType) {
         return firstAvailableSlot[processType.getValue()];
     }
 
@@ -78,8 +78,8 @@ final class AuxiliaryProcessesContainer {
 
         public int getProcessSlot() { return processSlot; }
 
-        public WKProcessType getProcessType() { return serviceConnection.getProcessType(); }
+        public WPEProcessType getProcessType() { return serviceConnection.getProcessType(); }
 
-        public void terminate() { WKRuntime.getInstance().getApplicationContext().unbindService(serviceConnection); }
+        public void terminate() { WPERuntime.getInstance().getApplicationContext().unbindService(serviceConnection); }
     }
 }

--- a/wpeview/src/main/java/org/wpewebkit/wpe/WPEActivityObserver.java
+++ b/wpeview/src/main/java/org/wpewebkit/wpe/WPEActivityObserver.java
@@ -26,8 +26,8 @@ import android.util.Log;
 
 import androidx.annotation.NonNull;
 
-public class WKActivityObserver implements Application.ActivityLifecycleCallbacks {
-    private static final String LOGTAG = "WKActivityObserver";
+public class WPEActivityObserver implements Application.ActivityLifecycleCallbacks {
+    private static final String LOGTAG = "WPEActivityObserver";
 
     @Override
     public void onActivityCreated(@NonNull Activity a, @NonNull Bundle b) {

--- a/wpeview/src/main/java/org/wpewebkit/wpe/WPEProcessType.java
+++ b/wpeview/src/main/java/org/wpewebkit/wpe/WPEProcessType.java
@@ -22,17 +22,23 @@ package org.wpewebkit.wpe;
 
 import androidx.annotation.NonNull;
 
-public enum WKProcessType {
+/**
+ * The types of WebKit auxiliary processes hosted in Android Services. This is not a mirror of the
+ * WPEPlatform WPEProcessType C enumeration: values must stay in sync with the native ProcessType in
+ * Common/Environment.h, and the constant names are used to resolve the generated WPEServices
+ * service classes by reflection.
+ */
+public enum WPEProcessType {
     WebProcess(0),
     NetworkProcess(1),
     WebDriverProcess(2);
 
     private final int value;
 
-    WKProcessType(int value) { this.value = value; }
+    WPEProcessType(int value) { this.value = value; }
 
-    public static @NonNull WKProcessType fromValue(int value) {
-        for (WKProcessType entry : WKProcessType.values()) {
+    public static @NonNull WPEProcessType fromValue(int value) {
+        for (WPEProcessType entry : WPEProcessType.values()) {
             if (entry.getValue() == value)
                 return entry;
         }

--- a/wpeview/src/main/java/org/wpewebkit/wpe/WPERuntime.java
+++ b/wpeview/src/main/java/org/wpewebkit/wpe/WPERuntime.java
@@ -44,8 +44,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 @UiThread
-public final class WKRuntime {
-    private static final String LOGTAG = "WKRuntime";
+public final class WPERuntime {
+    private static final String LOGTAG = "WPERuntime";
 
     private static native void setupNativeEnvironment(@NonNull String[] envStringsArray);
     private static native void setApplicationContext(Context context);
@@ -55,19 +55,19 @@ public final class WKRuntime {
     private static int inspectorPort = 0;
     private static boolean useHttpInspector = true;
 
-    private static final WKRuntime singleton = new WKRuntime();
+    private static final WPERuntime singleton = new WPERuntime();
 
-    public static @NonNull WKRuntime getInstance() { return singleton; }
+    public static @NonNull WPERuntime getInstance() { return singleton; }
 
-    private WKRuntime() { Log.v(LOGTAG, "WKRuntime creation"); }
+    private WPERuntime() { Log.v(LOGTAG, "WPERuntime creation"); }
 
     private Context applicationContext = null;
 
     public @Nullable Context getApplicationContext() { return applicationContext; }
 
     public static void enableRemoteInspector(int inspectorPort, boolean useHttpInspector) {
-        WKRuntime.inspectorPort = inspectorPort;
-        WKRuntime.useHttpInspector = useHttpInspector;
+        WPERuntime.inspectorPort = inspectorPort;
+        WPERuntime.useHttpInspector = useHttpInspector;
     }
 
     public void initialize(@NonNull Context context) {
@@ -75,7 +75,7 @@ public final class WKRuntime {
             applicationContext = context.getApplicationContext();
             setApplicationContext(applicationContext);
 
-            final String assetsVersion = WKVersions.versionedAssets("ui_process");
+            final String assetsVersion = WPEVersions.versionedAssets("ui_process");
             if (ServiceUtils.needAssets(applicationContext, assetsVersion)) {
                 ServiceUtils.copyFileOrDir(applicationContext, applicationContext.getAssets(), "injected-bundles",
                                            true);
@@ -153,7 +153,7 @@ public final class WKRuntime {
     @Keep
     @WorkerThread
     public void launchProcess(long pid, int type, int fd) {
-        WKProcessType processType = WKProcessType.fromValue(type);
+        WPEProcessType processType = WPEProcessType.fromValue(type);
         Log.d(LOGTAG, "launchProcess " + processType.name() + " (pid: " + pid + ", fd: " + fd + ")");
 
         int processSlot = auxiliaryProcesses.getFirstAvailableSlot(processType);

--- a/wpeview/src/main/java/org/wpewebkit/wpe/WPEVersions.java
+++ b/wpeview/src/main/java/org/wpewebkit/wpe/WPEVersions.java
@@ -21,7 +21,7 @@ package org.wpewebkit.wpe;
 
 import androidx.annotation.NonNull;
 
-public class WKVersions {
+public class WPEVersions {
     public static int WEBKIT_MAJOR = 0;
     public static int WEBKIT_MINOR = 0;
     public static int WEBKIT_MICRO = 0;

--- a/wpeview/src/main/java/org/wpewebkit/wpe/services/NetworkProcessService.java
+++ b/wpeview/src/main/java/org/wpewebkit/wpe/services/NetworkProcessService.java
@@ -27,8 +27,8 @@ import android.util.Log;
 
 import androidx.annotation.NonNull;
 
-import org.wpewebkit.wpe.WKProcessType;
-import org.wpewebkit.wpe.WKVersions;
+import org.wpewebkit.wpe.WPEProcessType;
+import org.wpewebkit.wpe.WPEVersions;
 
 import java.io.File;
 
@@ -45,7 +45,7 @@ public class NetworkProcessService extends WPEService {
 
         // android.os.Debug.waitForDebugger();
 
-        final String assetsVersion = WKVersions.versionedAssets("network_process");
+        final String assetsVersion = WPEVersions.versionedAssets("network_process");
         Context context = getApplicationContext();
         if (ServiceUtils.needAssets(context, assetsVersion)) {
             ServiceUtils.copyFileOrDir(context, getAssets(), "gio", true);
@@ -62,6 +62,6 @@ public class NetworkProcessService extends WPEService {
     protected void initializeServiceMain(long pid, @NonNull ParcelFileDescriptor parcelFd) {
         Log.d(LOGTAG,
               "initializeServiceMain() pid: " + pid + ", fd: " + parcelFd + ", native value: " + parcelFd.getFd());
-        initializeNativeMain(pid, WKProcessType.NetworkProcess.getValue(), parcelFd.detachFd());
+        initializeNativeMain(pid, WPEProcessType.NetworkProcess.getValue(), parcelFd.detachFd());
     }
 }

--- a/wpeview/src/main/java/org/wpewebkit/wpe/services/WPEServiceConnection.java
+++ b/wpeview/src/main/java/org/wpewebkit/wpe/services/WPEServiceConnection.java
@@ -35,19 +35,19 @@ import androidx.annotation.NonNull;
 
 import org.wpewebkit.wpe.IWPEService;
 import org.wpewebkit.wpe.IWPEServiceHost;
-import org.wpewebkit.wpe.WKProcessType;
+import org.wpewebkit.wpe.WPEProcessType;
 
 public final class WPEServiceConnection implements ServiceConnection {
     private static final String LOGTAG = "WPEServiceConnection";
 
     private final long pid;
-    private final WKProcessType processType;
+    private final WPEProcessType processType;
     private ParcelFileDescriptor parcelFd;
 
     protected final WPEServiceConnectionListener listener;
     protected final Handler handler = new Handler(Looper.myLooper());
 
-    public WPEServiceConnection(long pid, @NonNull WKProcessType processType, @NonNull ParcelFileDescriptor parcelFd,
+    public WPEServiceConnection(long pid, @NonNull WPEProcessType processType, @NonNull ParcelFileDescriptor parcelFd,
                                 @NonNull WPEServiceConnectionListener listener) {
         this.pid = pid;
         this.processType = processType;
@@ -56,7 +56,7 @@ public final class WPEServiceConnection implements ServiceConnection {
     }
 
     public long getPid() { return pid; }
-    public @NonNull WKProcessType getProcessType() { return processType; }
+    public @NonNull WPEProcessType getProcessType() { return processType; }
 
     @Override
     public void onServiceConnected(@NonNull ComponentName name, IBinder service) {

--- a/wpeview/src/main/java/org/wpewebkit/wpe/services/WebDriverProcessService.java
+++ b/wpeview/src/main/java/org/wpewebkit/wpe/services/WebDriverProcessService.java
@@ -6,8 +6,8 @@ import android.util.Log;
 
 import androidx.annotation.NonNull;
 
-import org.wpewebkit.wpe.WKProcessType;
-import org.wpewebkit.wpe.WKVersions;
+import org.wpewebkit.wpe.WPEProcessType;
+import org.wpewebkit.wpe.WPEVersions;
 
 import java.io.File;
 
@@ -25,7 +25,7 @@ public class WebDriverProcessService extends WPEService {
 
         // android.os.Debug.waitForDebugger();
 
-        final String assetsVersion = WKVersions.versionedAssets("webdriver_process");
+        final String assetsVersion = WPEVersions.versionedAssets("webdriver_process");
         Context context = getApplicationContext();
         if (ServiceUtils.needAssets(context, assetsVersion)) {
             ServiceUtils.copyFileOrDir(context, getAssets(), "gio", true);
@@ -41,6 +41,6 @@ public class WebDriverProcessService extends WPEService {
     protected void initializeServiceMain(long pid, @NonNull ParcelFileDescriptor parcelFd) {
         Log.d(LOGTAG, "initializeServiceMain()");
 
-        initializeNativeMain(pid, WKProcessType.WebDriverProcess.getValue(), 0);
+        initializeNativeMain(pid, WPEProcessType.WebDriverProcess.getValue(), 0);
     }
 }

--- a/wpeview/src/main/java/org/wpewebkit/wpe/services/WebProcessService.java
+++ b/wpeview/src/main/java/org/wpewebkit/wpe/services/WebProcessService.java
@@ -31,8 +31,8 @@ import android.util.Log;
 import androidx.annotation.NonNull;
 
 import org.freedesktop.gstreamer.GStreamer;
-import org.wpewebkit.wpe.WKProcessType;
-import org.wpewebkit.wpe.WKVersions;
+import org.wpewebkit.wpe.WPEProcessType;
+import org.wpewebkit.wpe.WPEVersions;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -53,7 +53,7 @@ public class WebProcessService extends WPEService {
 
         // android.os.Debug.waitForDebugger();
 
-        final String assetsVersion = WKVersions.versionedAssets("web_process");
+        final String assetsVersion = WPEVersions.versionedAssets("web_process");
         Context context = getApplicationContext();
         if (ServiceUtils.needAssets(context, assetsVersion)) {
             ServiceUtils.copyFileOrDir(context, getAssets(), "gstreamer-1.0", true);
@@ -173,6 +173,6 @@ public class WebProcessService extends WPEService {
     protected void initializeServiceMain(long pid, @NonNull ParcelFileDescriptor parcelFd) {
         Log.d(LOGTAG,
               "initializeServiceMain() pid: " + pid + ", fd: " + parcelFd + ", native value: " + parcelFd.getFd());
-        initializeNativeMain(pid, WKProcessType.WebProcess.getValue(), parcelFd.detachFd());
+        initializeNativeMain(pid, WPEProcessType.WebProcess.getValue(), parcelFd.detachFd());
     }
 }

--- a/wpeview/src/main/java/org/wpewebkit/wpeview/WebContext.java
+++ b/wpeview/src/main/java/org/wpewebkit/wpeview/WebContext.java
@@ -25,8 +25,8 @@ import android.view.Display;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import org.wpewebkit.wpe.WKRuntime;
 import org.wpewebkit.wpe.WPEDisplay;
+import org.wpewebkit.wpe.WPERuntime;
 import org.wpewebkit.wpe.WPEScreen;
 import org.wpewebkit.wpe.WebKitCookieManager;
 import org.wpewebkit.wpe.WebKitNetworkSession;
@@ -67,7 +67,7 @@ public class WebContext {
 
     public WebContext(@NonNull android.content.Context context, boolean automationMode, boolean ephemeralSession) {
         this.appContext = context.getApplicationContext();
-        WKRuntime.getInstance().initialize(appContext);
+        WPERuntime.getInstance().initialize(appContext);
 
         this.display = new WPEDisplay();
         this.screen = display.getScreen();
@@ -125,10 +125,10 @@ public class WebContext {
 
     /**
      * Enable WebKit's remote inspector server. Must be called before any {@link WebContext} is created.
-     * Delegates to {@link WKRuntime#enableRemoteInspector(int, boolean)}.
+     * Delegates to {@link WPERuntime#enableRemoteInspector(int, boolean)}.
      */
     public static void enableRemoteInspector(int inspectorPort, boolean useHttpInspector) {
-        WKRuntime.enableRemoteInspector(inspectorPort, useHttpInspector);
+        WPERuntime.enableRemoteInspector(inspectorPort, useHttpInspector);
     }
 
     /**


### PR DESCRIPTION
Finish the naming migration described in docs/architecture.md: the generic WK prefix is reserved for nothing anymore, so rename WKRuntime to WPERuntime, WKProcessType to WPEProcessType, WKActivityObserver to WPEActivityObserver and WKVersions to WPEVersions, together with the native Runtime/WPERuntime.{h,cpp} files, the wpeRuntime* process bridge functions and the JNI class signature strings in WPERuntime.cpp and Init.cpp. The WPEProcessType enum constant names are kept as they resolve the generated WPEServices classes by reflection.