### PR TITLE
Refresh the documentation after the libwpe removal

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,8 +37,8 @@ jobs:
             force-avd-creation: false
             emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
             disable-animations: true
-            pre-emulator-launch-script: ./gradlew wpe:build
-            script: ./gradlew wpe:connectedDebugAndroidTest --stacktrace
+            pre-emulator-launch-script: ./gradlew wpeview:build
+            script: ./gradlew wpeview:connectedDebugAndroidTest --stacktrace
         - name: Create Test Summary
           uses: test-summary/action@v2
           with:

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ Besides [python3](https://www.python.org/downloads/), additional dependencies ar
 ### Getting the dependencies
 
 WPE Android depends on a considerable amount of libraries,
-including [libWPE](https://github.com/WebPlatformForEmbedded/libwpe) and
-[WPEWebKit](https://github.com/WebPlatformForEmbedded/WPEWebKit).
+including [WPEWebKit](https://github.com/WebPlatformForEmbedded/WPEWebKit)
+and GStreamer.
 To ease the cross-compilation process we use
 [Cerbero](https://gitlab.freedesktop.org/gstreamer/cerbero). To set all things up run:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,9 +14,9 @@ new and existing code should use the APIs described below.
 
 ### Layer 0: Runtime and process infrastructure
 
-This layer initializes native libraries, configures the WebKit process provider,
-starts the native looper, bridges Android and GLib event delivery, and manages
-the Android services used for auxiliary processes.
+This layer initializes native libraries, bridges Android and GLib event
+delivery, and manages the Android services used for auxiliary processes on
+behalf of the WPEPlatform process manager.
 
 Java code lives in:
 
@@ -140,6 +140,7 @@ Native code lives in `wpeview/src/main/cpp/Platform/`:
 - `WPEViewAndroid.cpp`
 - `WPEInputMethodContextAndroid.cpp`
 - `WPEKeymapAndroid.cpp`
+- `WPEProcessManagerAndroid.cpp`
 - `WPEScreenAndroid.cpp`
 - `WPEScreenSyncObserverAndroid.cpp`
 

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -1,8 +1,8 @@
 #  Bootstrap process
 
 WPE Android depends on a considerable amount of libraries,
-including [libWPE](https://github.com/WebPlatformForEmbedded/libwpe) and
-[WPEWebKit](https://github.com/WebPlatformForEmbedded/WPEWebKit). To ease
+including [WPEWebKit](https://github.com/WebPlatformForEmbedded/WPEWebKit)
+and GStreamer. To ease
 the process of building and installing these dependencies we have a
 [bootstrap script](../tools/scripts/bootstrap.py) that can be run with the following command:
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -21,43 +21,15 @@ end of the command line.
 When a native crash occurs running WPE Android the adb logcat prints something like:
 
 ```
-03-12 12:20:39.315  I  [30472/30472] crash_dump64 obtaining output fd from tombstoned, type: kDebuggerdTombstone
-03-12 12:20:39.337  I  [904/904] tombstoned received crash request for pid 30465
-03-12 12:20:39.339  I  [30472/30472] crash_dump64 performing dump of process 30164 (target tid = 30465)
 03-12 12:20:39.345  F  [30472/30472] DEBUG    *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
 03-12 12:20:39.345  F  [30472/30472] DEBUG    Build fingerprint: 'google/redfin/redfin:11/RQ2A.210305.006/7119741:user/release-keys'
-03-12 12:20:39.345  F  [30472/30472] DEBUG    Revision: 'MP1.0'
-03-12 12:20:39.345  F  [30472/30472] DEBUG    ABI: 'arm64'
-03-12 12:20:39.346  F  [30472/30472] DEBUG    Timestamp: 2021-03-12 12:20:39+0100
 03-12 12:20:39.346  F  [30472/30472] DEBUG    pid: 30164, tid: 30465, name: Thread-5  >>> org.wpewebkit.tools.minibrowser <<<
-03-12 12:20:39.346  F  [30472/30472] DEBUG    uid: 10393
 03-12 12:20:39.346  F  [30472/30472] DEBUG    signal 6 (SIGABRT), code -1 (SI_QUEUE), fault addr --------
-03-12 12:20:39.346  F  [30472/30472] DEBUG        x0  0000000000000000  x1  0000000000007701  x2  0000000000000006  x3  0000007260758900
-03-12 12:20:39.346  F  [30472/30472] DEBUG        x4  0000000000000000  x5  0000000000000000  x6  0000000000000000  x7  0000000000000000
-03-12 12:20:39.346  F  [30472/30472] DEBUG        x8  00000000000000f0  x9  0000007502cfb7c0  x10 ffffff80fffffbdf  x11 0000000000000001
-03-12 12:20:39.346  F  [30472/30472] DEBUG        x12 0000000000000000  x13 47c3000000020102  x14 000000000000008f  x15 00000000000008f0
-03-12 12:20:39.346  F  [30472/30472] DEBUG        x16 0000007502d93c80  x17 0000007502d75320  x18 00000071fbeb2000  x19 00000000000075d4
-03-12 12:20:39.346  F  [30472/30472] DEBUG        x20 0000000000007701  x21 00000000ffffffff  x22 00000071b24ee5d8  x23 00000071b24ee3a8
-03-12 12:20:39.346  F  [30472/30472] DEBUG        x24 00000071b24ee4a8  x25 000000726075a000  x26 0000000000000002  x27 0000007260758dd8
-03-12 12:20:39.346  F  [30472/30472] DEBUG        x28 0000007260758df8  x29 0000007260758980
-03-12 12:20:39.346  F  [30472/30472] DEBUG        lr  0000007502d29148  sp  00000072607588e0  pc  0000007502d29178  pst 0000000000001000
-03-12 12:20:39.498  D  [4505/4505] GRIL-S   [8730]> UPDATE_REGULATORY_DOMAIN
-03-12 12:20:39.496  W  [1001/1001] radioext@1.0-se type=1400 audit(0.0:32314): avc: denied { search } for name="radio" dev="dm-16" ino=212 scontext=u:r:hal_radioext_default:s0 tcontext=u:object_r:vendor_radio_data_file:s0 tclass=dir permissive=0
-03-12 12:20:39.499  D  [4505/5555] GRIL-S   [8730]< UPDATE_REGULATORY_DOMAIN
 03-12 12:20:39.515  F  [30472/30472] DEBUG    backtrace:
 03-12 12:20:39.515  F  [30472/30472] DEBUG          #00 pc 000000000004e178  /apex/com.android.runtime/lib64/bionic/libc.so (abort+168) (BuildId: bca874ad82277777df5c95ca3b0f6e6f)
-03-12 12:20:39.515  F  [30472/30472] DEBUG          #01 pc 0000000000601a24  /data/app/~~WJLHau6kHswZ6spsTXvQUw==/org.wpewebkit.tools.minibrowser-VIWitBTgpOsWgxNfsbpj1Q==/lib/arm64/libWPEWebKit-1.0_3.so
-03-12 12:20:39.515  F  [30472/30472] DEBUG          #02 pc 000000000088fd1c  /data/app/~~WJLHau6kHswZ6spsTXvQUw==/org.wpewebkit.tools.minibrowser-VIWitBTgpOsWgxNfsbpj1Q==/lib/arm64/libWPEWebKit-1.0_3.so
-03-12 12:20:39.515  F  [30472/30472] DEBUG          #03 pc 000000000088c804  /data/app/~~WJLHau6kHswZ6spsTXvQUw==/org.wpewebkit.tools.minibrowser-VIWitBTgpOsWgxNfsbpj1Q==/lib/arm64/libWPEWebKit-1.0_3.so
-03-12 12:20:39.515  F  [30472/30472] DEBUG          #04 pc 00000000008fdff4  /data/app/~~WJLHau6kHswZ6spsTXvQUw==/org.wpewebkit.tools.minibrowser-VIWitBTgpOsWgxNfsbpj1Q==/lib/arm64/libWPEWebKit-1.0_3.so
-03-12 12:20:39.515  F  [30472/30472] DEBUG          #05 pc 00000000008eccfc  /data/app/~~WJLHau6kHswZ6spsTXvQUw==/org.wpewebkit.tools.minibrowser-VIWitBTgpOsWgxNfsbpj1Q==/lib/arm64/libWPEWebKit-1.0_3.so
-03-12 12:20:39.515  F  [30472/30472] DEBUG          #06 pc 00000000008e81cc  /data/app/~~WJLHau6kHswZ6spsTXvQUw==/org.wpewebkit.tools.minibrowser-VIWitBTgpOsWgxNfsbpj1Q==/lib/arm64/libWPEWebKit-1.0_3.so
-03-12 12:20:39.515  F  [30472/30472] DEBUG          #07 pc 00000000008f354c  /data/app/~~WJLHau6kHswZ6spsTXvQUw==/org.wpewebkit.tools.minibrowser-VIWitBTgpOsWgxNfsbpj1Q==/lib/arm64/libWPEWebKit-1.0_3.so
-03-12 12:20:39.515  F  [30472/30472] DEBUG          #08 pc 000000000001a580  /data/app/~~WJLHau6kHswZ6spsTXvQUw==/org.wpewebkit.tools.minibrowser-VIWitBTgpOsWgxNfsbpj1Q==/lib/arm64/libgobject-2.0.so
-03-12 12:20:39.515  F  [30472/30472] DEBUG          #09 pc 000000000001a2c8  /data/app/~~WJLHau6kHswZ6spsTXvQUw==/org.wpewebkit.tools.minibrowser-VIWitBTgpOsWgxNfsbpj1Q==/lib/arm64/libgobject-2.0.so (g_object_new_valist+760)
-03-12 12:20:39.515  F  [30472/30472] DEBUG          #10 pc 0000000000019dd0  /data/app/~~WJLHau6kHswZ6spsTXvQUw==/org.wpewebkit.tools.minibrowser-VIWitBTgpOsWgxNfsbpj1Q==/lib/arm64/libgobject-2.0.so (g_object_new+112)
-03-12 12:20:39.515  F  [30472/30472] DEBUG          #11 pc 00000000008ff7e0  /data/app/~~WJLHau6kHswZ6spsTXvQUw==/org.wpewebkit.tools.minibrowser-VIWitBTgpOsWgxNfsbpj1Q==/lib/arm64/libWPEWebKit-1.0_3.so (webkit_web_view_new+64)
-03-12 12:20:39.515  F  [30472/30472] DEBUG          #12 pc 0000000000043220  /data/app/~~WJLHau6kHswZ6spsTXvQUw==/org.wpewebkit.tools.minibrowser-VIWitBTgpOsWgxNfsbpj1Q==/lib/arm64/libWPEPageGlue.so (BuildId: f7e820673ca7de23f522c1742eca350cbb41d82d)
+03-12 12:20:39.515  F  [30472/30472] DEBUG          #01 pc 0000000000601a24  /data/app/~~WJLHau6kHswZ6spsTXvQUw==/org.wpewebkit.tools.minibrowser-VIWitBTgpOsWgxNfsbpj1Q==/lib/arm64/libWPEWebKit-2.0.so
+03-12 12:20:39.515  F  [30472/30472] DEBUG          #02 pc 000000000088fd1c  /data/app/~~WJLHau6kHswZ6spsTXvQUw==/org.wpewebkit.tools.minibrowser-VIWitBTgpOsWgxNfsbpj1Q==/lib/arm64/libWPEWebKit-2.0.so
+03-12 12:20:39.515  F  [30472/30472] DEBUG          #03 pc 0000000000043220  /data/app/~~WJLHau6kHswZ6spsTXvQUw==/org.wpewebkit.tools.minibrowser-VIWitBTgpOsWgxNfsbpj1Q==/lib/arm64/libWPEAndroidRuntime.so
 ```
 
 This is not specially helpful, as it shows shared library addresses instead of the usual `<source-file>:<line-number`.
@@ -65,7 +37,7 @@ To turn this output into something more readable you need to make use of the `nd
 we need with Cerbero. Run this command from the WPE Android root path:
 
 ```ssh
-adb logcat | cerbero/build/android-ndk-23/ndk-stack -sym wpeview/src/main/cpp/imported/lib/arm64-v8a
+adb logcat | build/cerbero/build/android-ndk-27/ndk-stack -sym wpeview/src/main/cpp/imported/lib/arm64-v8a
 ```
 
 You should see something like:
@@ -73,38 +45,13 @@ You should see something like:
 ```
 ********** Crash dump: **********
 Build fingerprint: 'google/redfin/redfin:11/RQ2A.210305.006/7119741:user/release-keys'
-WARNING: Mismatched build id for wpe/imported/lib/arm64-v8a/libc.so
-WARNING:   Expected bca874ad82277777df5c95ca3b0f6e6f
-WARNING:   Found    c790eec6e15870bab2cf223ed3cfa192
 #00 0x000000000004e178 /apex/com.android.runtime/lib64/bionic/libc.so (abort+168) (BuildId: bca874ad82277777df5c95ca3b0f6e6f)
-#01 0x0000000000601a24 /data/app/~~WJLHau6kHswZ6spsTXvQUw==/org.wpewebkit.tools.minibrowser-VIWitBTgpOsWgxNfsbpj1Q==/lib/arm64/libWPEWebKit-1.0_3.so
+#01 0x0000000000601a24 /data/app/~~WJLHau6kHswZ6spsTXvQUw==/org.wpewebkit.tools.minibrowser-VIWitBTgpOsWgxNfsbpj1Q==/lib/arm64/libWPEWebKit-2.0.so
 WTFCrashWithInfo(int, char const*, char const*, int)
-/home/ferjm/dev/igalia/wpe-android/cerbero/build/sources/android_arm64/wpewebkit-2.30.4/_builddir/DerivedSources/ForwardingHeaders/wtf/Assertions.h:673:5
-#02 0x000000000088fd1c /data/app/~~WJLHau6kHswZ6spsTXvQUw==/org.wpewebkit.tools.minibrowser-VIWitBTgpOsWgxNfsbpj1Q==/lib/arm64/libWPEWebKit-1.0_3.so
+/home/user/dev/wpe-android/build/cerbero/build/sources/android_arm64/wpewebkit-git/_builddir/DerivedSources/ForwardingHeaders/wtf/Assertions.h:673:5
+#02 0x000000000088fd1c /data/app/~~WJLHau6kHswZ6spsTXvQUw==/org.wpewebkit.tools.minibrowser-VIWitBTgpOsWgxNfsbpj1Q==/lib/arm64/libWPEWebKit-2.0.so
 WebKit::WebProcessProxy::WebProcessProxy(WebKit::WebProcessPool&, WebKit::WebsiteDataStore*, WebKit::WebProcessProxy::IsPrewarmed)
-/home/ferjm/dev/igalia/wpe-android/cerbero/build/sources/android_arm64/wpewebkit-2.30.4/_builddir/../Source/WebKit/UIProcess/WebProcessProxy.cpp:205:5
-#03 0x000000000088c804 /data/app/~~WJLHau6kHswZ6spsTXvQUw==/org.wpewebkit.tools.minibrowser-VIWitBTgpOsWgxNfsbpj1Q==/lib/arm64/libWPEWebKit-1.0_3.so
-WebKit::WebProcessProxy::create(WebKit::WebProcessPool&, WebKit::WebsiteDataStore*, WebKit::WebProcessProxy::IsPrewarmed, WebKit::WebProcessProxy::ShouldLaunchProcess)
-/home/ferjm/dev/igalia/wpe-android/cerbero/build/sources/android_arm64/wpewebkit-2.30.4/_builddir/../Source/WebKit/UIProcess/WebProcessProxy.cpp:141:32
-WebKit::WebProcessPool::createWebPage(WebKit::PageClient&, WTF::Ref<API::PageConfiguration, WTF::DumbPtrTraits<API::PageConfiguration> >&&)
-/home/ferjm/dev/igalia/wpe-android/cerbero/build/sources/android_arm64/wpewebkit-2.30.4/_builddir/../Source/WebKit/UIProcess/WebProcessPool.cpp:1320:0
-#04 0x00000000008fdff4 /data/app/~~WJLHau6kHswZ6spsTXvQUw==/org.wpewebkit.tools.minibrowser-VIWitBTgpOsWgxNfsbpj1Q==/lib/arm64/libWPEWebKit-1.0_3.so
-WKWPE::View::View(wpe_view_backend*, API::PageConfiguration const&)
-/home/ferjm/dev/igalia/wpe-android/cerbero/build/sources/android_arm64/wpewebkit-2.30.4/_builddir/../Source/WebKit/UIProcess/API/wpe/WPEView.cpp:74:25
-#05 0x00000000008eccfc /data/app/~~WJLHau6kHswZ6spsTXvQUw==/org.wpewebkit.tools.minibrowser-VIWitBTgpOsWgxNfsbpj1Q==/lib/arm64/libWPEWebKit-1.0_3.so
-WKWPE::View::create(wpe_view_backend*, API::PageConfiguration const&)
-/home/ferjm/dev/igalia/wpe-android/cerbero/build/sources/android_arm64/wpewebkit-2.30.4/_builddir/../Source/WebKit/UIProcess/API/wpe/WPEView.h:70:20
-webkitWebViewCreatePage(_WebKitWebView*, WTF::Ref<API::PageConfiguration, WTF::DumbPtrTraits<API::PageConfiguration> >&&)
-/home/ferjm/dev/igalia/wpe-android/cerbero/build/sources/android_arm64/wpewebkit-2.30.4/_builddir/../Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:2276:0
-#06 0x00000000008e81cc /data/app/~~WJLHau6kHswZ6spsTXvQUw==/org.wpewebkit.tools.minibrowser-VIWitBTgpOsWgxNfsbpj1Q==/lib/arm64/libWPEWebKit-1.0_3.so
-webkitWebContextCreatePageForWebView(_WebKitWebContext*, _WebKitWebView*, _WebKitUserContentManager*, _WebKitWebView*, _WebKitWebsitePolicies*)
-/home/ferjm/dev/igalia/wpe-android/cerbero/build/sources/android_arm64/wpewebkit-2.30.4/_builddir/../Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp:1926:5
-#07 0x00000000008f354c /data/app/~~WJLHau6kHswZ6spsTXvQUw==/org.wpewebkit.tools.minibrowser-VIWitBTgpOsWgxNfsbpj1Q==/lib/arm64/libWPEWebKit-1.0_3.so
-webkitWebViewConstructed(_GObject*)
-/home/ferjm/dev/igalia/wpe-android/cerbero/build/sources/android_arm64/wpewebkit-2.30.4/_builddir/../Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:765:5
-#08 0x000000000001a580 /data/app/~~WJLHau6kHswZ6spsTXvQUw==/org.wpewebkit.tools.minibrowser-VIWitBTgpOsWgxNfsbpj1Q==/lib/arm64/libgobject-2.0.so
-g_object_new_internal
-/home/ferjm/dev/igalia/wpe-android/cerbero/build/sources/android_arm64/glib-2.62.6/_builddir/../gobject/gobject.c:1867:5
+/home/user/dev/wpe-android/build/cerbero/build/sources/android_arm64/wpewebkit-git/_builddir/../Source/WebKit/UIProcess/WebProcessProxy.cpp:205:5
 
 [...]
 ```

--- a/tools/scripts/bootstrap.py
+++ b/tools/scripts/bootstrap.py
@@ -90,7 +90,7 @@ class Bootstrap:
     _devel_package_name_template = "wpewebkit-android-{arch}-{version}.tar.xz"
     _runtime_package_name_template = "wpewebkit-android-{arch}-{version}-runtime.tar.xz"
 
-    # These are the libraries that the glue code link with and that are required during build
+    # These are the libraries that the native runtime libraries link with and that are required during build
     # time. These libraries go into the `imported` folder and cannot go into the `jniLibs`
     # folder to avoid duplicated libraries.
     _build_libs = [

--- a/wpeview/src/main/java/org/wpewebkit/wpeview/WebView.java
+++ b/wpeview/src/main/java/org/wpewebkit/wpeview/WebView.java
@@ -283,7 +283,7 @@ public class WebView extends FrameLayout {
     public void loadDataWithBaseURL(@Nullable String baseUrl, @NonNull String data, @Nullable String mimeType,
                                     @Nullable String encoding, @Nullable String historyUrl) {
         // Mirrors android.webkit.WebView.loadDataWithBaseURL: extra args are advisory.
-        // The current backend always parses content as UTF-8 HTML.
+        // The engine always parses content as UTF-8 HTML.
         loadHtml(data, baseUrl);
     }
 


### PR DESCRIPTION
Drop the libWPE dependency claim from README.md and docs/bootstrap.md, modernize the docs/development.md crash dump walkthrough (current library names and NDK path instead of the WPEWebKit 1.0 era example through libWPEPageGlue), reword the bootstrap.py glue-code comment, add WPEProcessManagerAndroid.cpp to the architecture Layer 3 list and stop describing the removed native looper. Also fix the stale wpe: module name in the CI workflow, renamed to wpeview: long ago.