### PR TITLE
wpeview: Build the native glue without C++ exceptions

### DIFF
--- a/tools/jni-test/CMakeLists.txt
+++ b/tools/jni-test/CMakeLists.txt
@@ -35,6 +35,7 @@ add_library(
     cpp/TestStaticMethods.cpp)
 target_compile_features(jniTest PRIVATE cxx_std_17)
 target_compile_definitions(jniTest PRIVATE USE_JAVA_JDK)
+target_include_directories(jniTest PRIVATE cpp)
 target_compile_options(jniTest PRIVATE -Wall -Werror)
 target_link_libraries(jniTest PRIVATE JNI::JNI)
 

--- a/tools/jni-test/cpp/Logging.h
+++ b/tools/jni-test/cpp/Logging.h
@@ -1,0 +1,52 @@
+/**
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#pragma once
+
+// Host version of wpeview/src/main/cpp/Common/Logging.h used by the JNI layer
+// when it is built for the jni-test harness: logs go to stderr.
+
+#include <cstdio>
+#include <utility>
+
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define UNUSED_PARAM(variable) (void)(variable)
+
+namespace Logging {
+
+template <typename... Args> constexpr void logError(const char* format, Args&&... args) noexcept
+{
+    if constexpr (sizeof...(Args) == 0) {
+        std::fprintf(stderr, "%s\n", format);
+    } else {
+        std::fprintf(stderr, format, std::forward<Args>(args)...);
+        std::fputc('\n', stderr);
+    }
+}
+
+template <typename... Args> constexpr void logVerbose(const char* format, Args&&... args) noexcept
+{
+    logError(format, std::forward<Args>(args)...);
+}
+
+template <typename... Args> constexpr void logDebug(const char* format, Args&&... args) noexcept
+{
+    logError(format, std::forward<Args>(args)...);
+}
+
+} // namespace Logging

--- a/tools/jni-test/cpp/Main.cpp
+++ b/tools/jni-test/cpp/Main.cpp
@@ -28,20 +28,16 @@
 
 extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* javaVM, void* /*reserved*/)
 {
-    try {
-        JNI::initVM(javaVM);
-        JNI::Class("jni/Test")
-            .registerNativeMethods(JNI::StaticNativeMethod<void()>("testConstructors", TestConstructors::executeTests),
-                JNI::StaticNativeMethod<void()>("testDuplexCalls", TestDuplexCalls::executeTests),
-                JNI::StaticNativeMethod<void()>("testFields", TestFields::executeTests),
-                JNI::StaticNativeMethod<void()>("testMethods", TestMethods::executeTests),
-                JNI::StaticNativeMethod<void()>("testObjectArrays", TestObjectArrays::executeTests),
-                JNI::StaticNativeMethod<void()>("testScalarArrays", TestScalarArrays::executeTests),
-                JNI::StaticNativeMethod<void()>("testStaticFields", TestStaticFields::executeTests),
-                JNI::StaticNativeMethod<void()>("testStaticMethods", TestStaticMethods::executeTests));
+    JNI::initVM(javaVM);
+    JNI::Class("jni/Test")
+        .registerNativeMethods(JNI::StaticNativeMethod<void()>("testConstructors", TestConstructors::executeTests),
+            JNI::StaticNativeMethod<void()>("testDuplexCalls", TestDuplexCalls::executeTests),
+            JNI::StaticNativeMethod<void()>("testFields", TestFields::executeTests),
+            JNI::StaticNativeMethod<void()>("testMethods", TestMethods::executeTests),
+            JNI::StaticNativeMethod<void()>("testObjectArrays", TestObjectArrays::executeTests),
+            JNI::StaticNativeMethod<void()>("testScalarArrays", TestScalarArrays::executeTests),
+            JNI::StaticNativeMethod<void()>("testStaticFields", TestStaticFields::executeTests),
+            JNI::StaticNativeMethod<void()>("testStaticMethods", TestStaticMethods::executeTests));
 
-        return JNI::VERSION;
-    } catch (...) {
-        return JNI_ERR;
-    }
+    return JNI::VERSION;
 }

--- a/tools/jni-test/cpp/TestDuplexCalls.cpp
+++ b/tools/jni-test/cpp/TestDuplexCalls.cpp
@@ -82,9 +82,9 @@ void TestDuplexCalls::callNativeMethodThroughJava(int value)
     getJNIClassCache().m_callNativeMethod.invoke(m_javaInstance.get(), value);
 }
 
-void TestDuplexCalls::throwingMethod() const
+bool TestDuplexCalls::throwingMethod() const
 {
-    getJNIClassCache().m_throwingMethod.invoke(m_javaInstance.get());
+    return getJNIClassCache().m_throwingMethod.invoke(m_javaInstance.get());
 }
 
 void TestDuplexCalls::executeTests(JNIEnv* env, jclass klass)
@@ -103,12 +103,7 @@ void TestDuplexCalls::executeTests(JNIEnv* env, jclass klass)
     assert(test.getValue() == 8);
 
     JNI::enableJavaExceptionDescription(false);
-    bool throwing = false;
-    try {
-        test.throwingMethod();
-    } catch (...) {
-        throwing = true;
-    }
+    // The Java exception is logged and cleared, and the invocation reports the failure.
+    assert(!test.throwingMethod());
     JNI::enableJavaExceptionDescription(true);
-    assert(throwing);
 }

--- a/tools/jni-test/cpp/TestDuplexCalls.h
+++ b/tools/jni-test/cpp/TestDuplexCalls.h
@@ -33,7 +33,7 @@ public:
     int getValue() const;
 
     void callNativeMethodThroughJava(int value);
-    void throwingMethod() const;
+    bool throwingMethod() const;
 
 private:
     bool m_addTwoHasBeenCalled = false;

--- a/wpeview/src/main/cpp/CMakeLists.txt
+++ b/wpeview/src/main/cpp/CMakeLists.txt
@@ -29,6 +29,8 @@ function(target_configure_quality TARGET_NAME)
         set_target_properties(${TARGET_NAME} PROPERTIES CXX_CLANG_TIDY "${CLANG_TIDY_EXE}")
     endif()
 
+    target_compile_options(${TARGET_NAME} PRIVATE -fno-exceptions)
+
     if(USE_CODE_WARNINGS_AS_ERRORS)
         target_compile_options(${TARGET_NAME} PRIVATE -Wall -Wextra -Werror)
     endif()
@@ -95,7 +97,7 @@ set_target_properties(WPEWebDriver PROPERTIES IMPORTED_LOCATION
 add_library(WPEAndroidCommon SHARED Common/Environment.cpp Common/Init.cpp Common/Logging.cpp Common/JNI/JNIClass.cpp
                                     Common/JNI/JNIEnv.cpp Common/JNI/JNIString.cpp)
 target_configure_quality(WPEAndroidCommon)
-target_include_directories(WPEAndroidCommon INTERFACE Common)
+target_include_directories(WPEAndroidCommon PUBLIC Common)
 target_link_libraries(
     WPEAndroidCommon
     ${android-lib}

--- a/wpeview/src/main/cpp/Common/Environment.cpp
+++ b/wpeview/src/main/cpp/Common/Environment.cpp
@@ -29,20 +29,23 @@ bool Environment::configureEnvironment(jstringArray envStringsArray) noexcept
     if (envStringsArray == nullptr)
         return true;
 
-    try {
-        auto content = JNI::ObjectArray<jstring>(envStringsArray).getReadOnlyContent();
-        const size_t size = content.getSize();
+    auto content = JNI::ObjectArray<jstring>(envStringsArray).getReadOnlyContent();
+    const size_t size = content.getSize();
 
-        assert(size % 2 == 0);
-        for (size_t i = 1; i < size; i += 2) {
-            auto name = JNI::String(content[i - 1]);
-            auto value = JNI::String(content[i]);
-            setenv(name.getContent().get(), value.getContent().get(), 1); // NOLINT(concurrency-mt-unsafe)
+    assert(size % 2 == 0);
+    for (size_t i = 1; i < size; i += 2) {
+        // The JNI::String instances must outlive the content pointers whose release
+        // references the underlying Java string.
+        auto name = JNI::String(content[i - 1]);
+        auto value = JNI::String(content[i]);
+        auto nameContent = name.getContent();
+        auto valueContent = value.getContent();
+        if (!nameContent || !valueContent) {
+            Logging::logError("Cannot configure native environment (JNI environment error)");
+            return false;
         }
-
-        return true;
-    } catch (...) {
-        Logging::logError("Cannot configure native environment (JNI environment error)");
-        return false;
+        setenv(nameContent.get(), valueContent.get(), 1); // NOLINT(concurrency-mt-unsafe)
     }
+
+    return true;
 }

--- a/wpeview/src/main/cpp/Common/JNI/JNIClass.cpp
+++ b/wpeview/src/main/cpp/Common/JNI/JNIClass.cpp
@@ -22,13 +22,13 @@
 JNI::Class::Class(jobject obj, bool useGlobalRef)
 {
     if (obj == nullptr)
-        throw std::runtime_error("Invalid null Java object");
+        fatalError("Invalid null Java object");
 
     auto* env = getCurrentThreadJNIEnv();
     jclass klass = env->GetObjectClass(obj);
     if (klass == nullptr) {
-        checkJavaException(env);
-        throw std::runtime_error("Cannot fetch Java object class");
+        clearJavaException(env);
+        fatalError("Cannot fetch Java object class");
     }
 
     m_javaClassRef = createTypedProtectedRef(env, std::move(klass), useGlobalRef);
@@ -37,13 +37,15 @@ JNI::Class::Class(jobject obj, bool useGlobalRef)
 JNI::Class::Class(const char* javaClassName, bool useGlobalRef)
 {
     if ((javaClassName == nullptr) || (javaClassName[0] == '\0'))
-        throw std::runtime_error("Invalid Java class name");
+        fatalError("Invalid Java class name");
 
+    // A failed lookup leaves the class null so callers can probe for optional classes;
+    // using any member of a null Class aborts.
     auto* env = getCurrentThreadJNIEnv();
     jclass klass = env->FindClass(javaClassName);
     if (klass == nullptr) {
-        checkJavaException(env);
-        throw std::runtime_error("Cannot fetch Java class from name");
+        clearJavaException(env);
+        return;
     }
 
     m_javaClassRef = createTypedProtectedRef(env, std::move(klass), useGlobalRef);
@@ -52,7 +54,7 @@ JNI::Class::Class(const char* javaClassName, bool useGlobalRef)
 JNI::Class::Class(const jclass& javaClass, bool useGlobalRef)
 {
     if (javaClass == nullptr)
-        throw std::runtime_error("Invalid null Java class");
+        fatalError("Invalid null Java class");
 
     m_javaClassRef = createTypedProtectedRef(getCurrentThreadJNIEnv(), javaClass, useGlobalRef);
 }
@@ -60,7 +62,7 @@ JNI::Class::Class(const jclass& javaClass, bool useGlobalRef)
 JNI::Class::Class(jclass&& javaClass, bool useGlobalRef)
 {
     if (javaClass == nullptr)
-        throw std::runtime_error("Invalid null Java class");
+        fatalError("Invalid null Java class");
 
     m_javaClassRef = createTypedProtectedRef(getCurrentThreadJNIEnv(), std::move(javaClass), useGlobalRef);
 }
@@ -70,8 +72,9 @@ JNI::ProtectedArrayType<jobject> JNI::Class::createArray(size_t size, jobject in
     auto* env = getCurrentThreadJNIEnv();
     jobjectArray objArray = env->NewObjectArray(static_cast<jsize>(size), m_javaClassRef.get(), initObj);
     if (objArray == nullptr) {
-        checkJavaException(env);
-        throw std::runtime_error("Cannot create array of Java objects");
+        clearJavaException(env);
+        Logging::logError("Cannot create array of Java objects");
+        return {};
     }
 
     return createTypedProtectedRef(env, std::move(objArray));
@@ -79,9 +82,5 @@ JNI::ProtectedArrayType<jobject> JNI::Class::createArray(size_t size, jobject in
 
 bool JNI::Class::operator==(const Class& other) const noexcept
 {
-    try {
-        return (getCurrentThreadJNIEnv()->IsSameObject(m_javaClassRef.get(), other.m_javaClassRef.get()) == JNI_TRUE);
-    } catch (...) {
-        return false;
-    }
+    return (getCurrentThreadJNIEnv()->IsSameObject(m_javaClassRef.get(), other.m_javaClassRef.get()) == JNI_TRUE);
 }

--- a/wpeview/src/main/cpp/Common/JNI/JNIClass.h
+++ b/wpeview/src/main/cpp/Common/JNI/JNIClass.h
@@ -73,8 +73,8 @@ public:
 
         auto* env = getCurrentThreadJNIEnv();
         if (env->RegisterNatives(m_javaClassRef.get(), methods, sizeof...(Args)) != JNI_OK) {
-            checkJavaException(env);
-            throw std::runtime_error("Cannot register native methods");
+            clearJavaException(env);
+            fatalError("Cannot register native methods");
         }
     }
 
@@ -103,8 +103,9 @@ public:
         auto* env = getCurrentThreadJNIEnv();
         jobjectArray objArray = env->NewObjectArray(static_cast<jsize>(size), m_javaClassRef.get(), initObj);
         if (objArray == nullptr) {
-            checkJavaException(env);
-            throw std::runtime_error("Cannot create array of Java objects");
+            clearJavaException(env);
+            Logging::logError("Cannot create array of Java objects");
+            return {};
         }
 
         return createTypedProtectedRef(env, std::move(reinterpret_cast<ArrayType<T>>(objArray)));

--- a/wpeview/src/main/cpp/Common/JNI/JNIConstructor.h
+++ b/wpeview/src/main/cpp/Common/JNI/JNIConstructor.h
@@ -35,8 +35,9 @@ public:
         auto* env = getCurrentThreadJNIEnv();
         jobject obj = env->NewObject(m_javaClassRef.get(), m_methodId, params...);
         if (obj == nullptr) {
-            checkJavaException(env);
-            throw std::runtime_error("Cannot create instance of a Java object");
+            clearJavaException(env);
+            Logging::logError("Cannot create instance of a Java object");
+            return {};
         }
 
         return createTypedProtectedRef(env, std::move(reinterpret_cast<Ret>(obj)));
@@ -50,8 +51,9 @@ public:
         if (size > 0) {
             initObj = env->NewObject(m_javaClassRef.get(), m_methodId, params...);
             if (initObj == nullptr) {
-                checkJavaException(env);
-                throw std::runtime_error("Cannot create instance of a Java object");
+                clearJavaException(env);
+                Logging::logError("Cannot create instance of a Java object");
+                return {};
             }
         }
 
@@ -60,8 +62,9 @@ public:
             env->DeleteLocalRef(initObj);
 
         if (objArray == nullptr) {
-            checkJavaException(env);
-            throw std::runtime_error("Cannot create array of Java objects");
+            clearJavaException(env);
+            Logging::logError("Cannot create array of Java objects");
+            return {};
         }
 
         return createTypedProtectedRef(env, std::move(reinterpret_cast<ArrayType<Ret>>(objArray)));
@@ -78,8 +81,8 @@ private:
         // TODO NOLINTNEXTLINE(bugprone-suspicious-stringview-data-usage)
         m_methodId = env->GetMethodID(m_javaClassRef.get(), "<init>", FunctionSignature<void(Params...)>::value.data());
         if (m_methodId == nullptr) {
-            checkJavaException(env);
-            throw std::runtime_error("Cannot find constructor in Java class");
+            clearJavaException(env);
+            fatalError("Cannot find constructor in Java class");
         }
     }
 

--- a/wpeview/src/main/cpp/Common/JNI/JNIEnv.cpp
+++ b/wpeview/src/main/cpp/Common/JNI/JNIEnv.cpp
@@ -21,6 +21,7 @@
 
 #include <atomic>
 #include <pthread.h>
+#include <string>
 
 namespace {
 // Android threads names have maximum 16 characters (including the terminating null char)
@@ -43,28 +44,55 @@ void detachTerminatedNativeThread(void* /*keyValue*/)
     if (globalJavaVM != nullptr)
         globalJavaVM->DetachCurrentThread();
 }
+
+// Fetches Throwable.toString() from an already cleared exception, so the JNI calls are legal.
+std::string exceptionDescription(JNIEnv* env, jthrowable exception)
+{
+    std::string description = "no description";
+    if (exception == nullptr)
+        return description;
+
+    jclass exceptionClass = env->GetObjectClass(exception);
+    if (exceptionClass != nullptr) {
+        jmethodID toStringMethod = env->GetMethodID(exceptionClass, "toString", "()Ljava/lang/String;");
+        if (toStringMethod != nullptr) {
+            auto str = reinterpret_cast<jstring>(env->CallObjectMethod(exception, toStringMethod));
+            if (env->ExceptionCheck() == JNI_TRUE)
+                env->ExceptionClear();
+            if (str != nullptr) {
+                if (const char* content = env->GetStringUTFChars(str, nullptr)) {
+                    description = content;
+                    env->ReleaseStringUTFChars(str, content);
+                }
+                env->DeleteLocalRef(str);
+            }
+        }
+        env->DeleteLocalRef(exceptionClass);
+    }
+    return description;
+}
 } // namespace
 
 JNIEnv* JNI::initVM(JavaVM* javaVM)
 {
     if (globalJavaVM != nullptr) {
-        throw std::runtime_error("Java VM already initialized for current process");
+        fatalError("Java VM already initialized for current process");
     }
     // TODO NOLINTNEXTLINE(misc-const-correctness)
     JNIEnv* env = nullptr;
     if (javaVM->GetEnv(reinterpret_cast<void**>(&env), VERSION) != JNI_OK) {
-        throw std::runtime_error("Cannot fetch JNIEnv from JavaVM initialization");
+        fatalError("Cannot fetch JNIEnv from JavaVM initialization");
     }
 
     if (pthread_key_create(&globalJNIEnvKey, detachTerminatedNativeThread) != 0) {
-        throw std::runtime_error("Cannot create pthread key for native threads");
+        fatalError("Cannot create pthread key for native threads");
     }
 
     globalJavaVM = javaVM;
     return env;
 }
 
-JNIEnv* JNI::getCurrentThreadJNIEnv()
+JNIEnv* JNI::tryGetCurrentThreadJNIEnv() noexcept
 {
     auto* env = reinterpret_cast<JNIEnv*>(pthread_getspecific(globalJNIEnvKey));
     if (env == nullptr && globalJavaVM != nullptr) {
@@ -86,8 +114,14 @@ JNIEnv* JNI::getCurrentThreadJNIEnv()
         }
     }
 
+    return env;
+}
+
+JNIEnv* JNI::getCurrentThreadJNIEnv()
+{
+    auto* env = tryGetCurrentThreadJNIEnv();
     if (env == nullptr)
-        throw std::runtime_error("Cannot fetch current thread JNIEnv");
+        fatalError("Cannot fetch current thread JNIEnv");
 
     return env;
 }
@@ -97,14 +131,21 @@ void JNI::enableJavaExceptionDescription(bool enable)
     globalEnableJavaExceptionDescription = enable;
 }
 
-void JNI::checkJavaException(JNIEnv* env)
+bool JNI::clearJavaException(JNIEnv* env)
 {
-    if (env->ExceptionCheck() == JNI_TRUE) {
-        if (globalEnableJavaExceptionDescription)
-            env->ExceptionDescribe();
-        env->ExceptionClear();
-        throw std::runtime_error("A Java exception has been thrown during JNI call");
-    }
+    if (env->ExceptionCheck() != JNI_TRUE)
+        return false;
+
+    jthrowable exception = env->ExceptionOccurred();
+    if (globalEnableJavaExceptionDescription)
+        env->ExceptionDescribe();
+    env->ExceptionClear();
+
+    Logging::logError(
+        "A Java exception has been thrown during JNI call (%s)", exceptionDescription(env, exception).c_str());
+    if (exception != nullptr)
+        env->DeleteLocalRef(exception);
+    return true;
 }
 
 JNI::ProtectedType<jobject> JNI::createProtectedRef(JNIEnv* env, const jobject& obj, bool useGlobalRef)
@@ -115,31 +156,25 @@ JNI::ProtectedType<jobject> JNI::createProtectedRef(JNIEnv* env, const jobject& 
     if (useGlobalRef) {
         jobject globalRef = env->NewGlobalRef(obj);
         if (globalRef == nullptr) {
-            checkJavaException(env);
-            throw std::runtime_error("Cannot create Java global ref");
+            clearJavaException(env);
+            fatalError("Cannot create Java global ref");
         }
 
         return {globalRef, [](jobject ref) {
-                    try {
-                        getCurrentThreadJNIEnv()->DeleteGlobalRef(ref);
-                        // TODO NOLINTNEXTLINE(bugprone-empty-catch)
-                    } catch (...) {
-                    }
+                    if (auto* env = tryGetCurrentThreadJNIEnv())
+                        env->DeleteGlobalRef(ref);
                 }};
     }
 
     jobject localRef = env->NewLocalRef(obj);
     if (localRef == nullptr) {
-        checkJavaException(env);
-        throw std::runtime_error("Cannot create Java local ref");
+        clearJavaException(env);
+        fatalError("Cannot create Java local ref");
     }
 
     return {localRef, [](jobject ref) {
-                try {
-                    getCurrentThreadJNIEnv()->DeleteLocalRef(ref);
-                    // TODO NOLINTNEXTLINE(bugprone-empty-catch)
-                } catch (...) {
-                }
+                if (auto* env = tryGetCurrentThreadJNIEnv())
+                    env->DeleteLocalRef(ref);
             }};
 }
 
@@ -154,24 +189,18 @@ JNI::ProtectedType<jobject> JNI::createProtectedRef(JNIEnv* env, jobject&& obj, 
         env->DeleteLocalRef(obj);
         obj = nullptr;
         if (globalRef == nullptr) {
-            checkJavaException(env);
-            throw std::runtime_error("Cannot create Java global ref");
+            clearJavaException(env);
+            fatalError("Cannot create Java global ref");
         }
 
         return {globalRef, [](jobject ref) {
-                    try {
-                        getCurrentThreadJNIEnv()->DeleteGlobalRef(ref);
-                        // TODO NOLINTNEXTLINE(bugprone-empty-catch)
-                    } catch (...) {
-                    }
+                    if (auto* env = tryGetCurrentThreadJNIEnv())
+                        env->DeleteGlobalRef(ref);
                 }};
     }
 
     return {obj, [](jobject ref) {
-                try {
-                    getCurrentThreadJNIEnv()->DeleteLocalRef(ref);
-                    // TODO NOLINTNEXTLINE(bugprone-empty-catch)
-                } catch (...) {
-                }
+                if (auto* env = tryGetCurrentThreadJNIEnv())
+                    env->DeleteLocalRef(ref);
             }};
 }

--- a/wpeview/src/main/cpp/Common/JNI/JNIEnv.h
+++ b/wpeview/src/main/cpp/Common/JNI/JNIEnv.h
@@ -19,9 +19,13 @@
 
 #pragma once
 
+// Resolved through the include path: the Android build provides Common/Logging.h while the
+// jni-test host harness provides its own stderr-based version.
+#include "Logging.h"
+
 #include "JNITypes.h"
 
-#include <stdexcept>
+#include <cstdlib>
 
 namespace JNI {
 constexpr jint VERSION = JNI_VERSION_1_6;
@@ -29,8 +33,22 @@ constexpr jint VERSION = JNI_VERSION_1_6;
 JNIEnv* initVM(JavaVM* javaVM);
 JNIEnv* getCurrentThreadJNIEnv();
 
+// Returns nullptr instead of aborting when no JNIEnv can be fetched (e.g. from cleanup code
+// running after the Java VM has been destroyed).
+JNIEnv* tryGetCurrentThreadJNIEnv() noexcept;
+
 void enableJavaExceptionDescription(bool enable);
-void checkJavaException(JNIEnv* env);
+
+// Logs and clears any pending Java exception. Returns true if an exception was pending.
+bool clearJavaException(JNIEnv* env);
+
+// Unrecoverable JNI usage errors (missing class, method, field, etc.) abort the process
+// with a logcat message instead of throwing: the library builds without C++ exceptions.
+template <typename... Args> [[noreturn]] void fatalError(Args&&... args) noexcept
+{
+    Logging::logError(std::forward<Args>(args)...);
+    std::abort();
+}
 
 ProtectedType<jobject> createProtectedRef(JNIEnv* env, const jobject& obj, bool useGlobalRef = false);
 
@@ -107,7 +125,8 @@ public:
     void reset() noexcept
     {
         if (m_ref) {
-            getCurrentThreadJNIEnv()->DeleteGlobalRef(m_ref);
+            if (auto* env = tryGetCurrentThreadJNIEnv())
+                env->DeleteGlobalRef(m_ref);
             m_ref = nullptr;
         }
     }

--- a/wpeview/src/main/cpp/Common/JNI/JNIField.h
+++ b/wpeview/src/main/cpp/Common/JNI/JNIField.h
@@ -52,7 +52,8 @@ public:
         } else {
             static_assert(!std::is_same_v<T, T>, "Invalid JNI scalar type");
         }
-        checkJavaException(env);
+        if (clearJavaException(env))
+            return {};
         return ret;
     }
 
@@ -79,7 +80,8 @@ public:
         } else {
             static_assert(!std::is_same_v<T, T>, "Invalid JNI scalar type");
         }
-        checkJavaException(env);
+        if (clearJavaException(env))
+            return {};
         return ret;
     }
 
@@ -105,7 +107,7 @@ public:
         } else {
             static_assert(!std::is_same_v<T, T>, "Invalid JNI scalar type");
         }
-        checkJavaException(env);
+        clearJavaException(env);
     }
 
     template <typename U = void> std::enable_if_t<isStatic, U> setValue(const T& value) const
@@ -130,7 +132,7 @@ public:
         } else {
             static_assert(!std::is_same_v<T, T>, "Invalid JNI scalar type");
         }
-        checkJavaException(env);
+        clearJavaException(env);
     }
 
 private:
@@ -148,8 +150,8 @@ private:
             m_fieldId = env->GetFieldID(m_javaClassRef.get(), fieldName, TypeSignature<T>::value.data());
         }
         if (m_fieldId == nullptr) {
-            checkJavaException(env);
-            throw std::runtime_error("Cannot find field in Java class");
+            clearJavaException(env);
+            fatalError("Cannot find field %s in Java class", fieldName);
         }
     }
 
@@ -163,8 +165,7 @@ public:
     {
         auto* env = getCurrentThreadJNIEnv();
         jobject ret = env->GetObjectField(obj, m_fieldId);
-        checkJavaException(env);
-        if (ret == nullptr)
+        if (clearJavaException(env) || (ret == nullptr))
             return {};
 
         return createTypedProtectedRef(env, std::move(reinterpret_cast<T>(ret)));
@@ -174,8 +175,7 @@ public:
     {
         auto* env = getCurrentThreadJNIEnv();
         jobject ret = env->GetStaticObjectField(m_javaClassRef.get(), m_fieldId);
-        checkJavaException(env);
-        if (ret == nullptr)
+        if (clearJavaException(env) || (ret == nullptr))
             return {};
 
         return createTypedProtectedRef(env, std::move(reinterpret_cast<T>(ret)));
@@ -185,14 +185,14 @@ public:
     {
         auto* env = getCurrentThreadJNIEnv();
         env->SetObjectField(obj, m_fieldId, value);
-        checkJavaException(env);
+        clearJavaException(env);
     }
 
     template <typename U = void> std::enable_if_t<isStatic, U> setValue(const T& value) const
     {
         auto* env = getCurrentThreadJNIEnv();
         env->SetStaticObjectField(m_javaClassRef.get(), m_fieldId, value);
-        checkJavaException(env);
+        clearJavaException(env);
     }
 
 private:
@@ -210,8 +210,8 @@ private:
             m_fieldId = env->GetFieldID(m_javaClassRef.get(), fieldName, TypeSignature<T>::value.data());
         }
         if (m_fieldId == nullptr) {
-            checkJavaException(env);
-            throw std::runtime_error("Cannot find field in Java class");
+            clearJavaException(env);
+            fatalError("Cannot find field %s in Java class", fieldName);
         }
     }
 

--- a/wpeview/src/main/cpp/Common/JNI/JNIMethod.h
+++ b/wpeview/src/main/cpp/Common/JNI/JNIMethod.h
@@ -29,18 +29,20 @@ template <typename T, bool isStatic, typename = void> class GenericMethod;
 
 template <typename... Params, bool isStatic> class GenericMethod<void(Params...), isStatic> final {
 public:
-    template <typename U = void> std::enable_if_t<!isStatic, U> invoke(jobject obj, Params... params) const
+    // Returns false if the called Java method threw an exception (logged and cleared).
+    template <typename U = bool> std::enable_if_t<!isStatic, U> invoke(jobject obj, Params... params) const
     {
         auto* env = getCurrentThreadJNIEnv();
         env->CallVoidMethod(obj, m_methodId, params...);
-        checkJavaException(env);
+        return !clearJavaException(env);
     }
 
-    template <typename U = void> std::enable_if_t<isStatic, U> invoke(Params... params) const
+    // Returns false if the called Java method threw an exception (logged and cleared).
+    template <typename U = bool> std::enable_if_t<isStatic, U> invoke(Params... params) const
     {
         auto* env = getCurrentThreadJNIEnv();
         env->CallStaticVoidMethod(m_javaClassRef.get(), m_methodId, params...);
-        checkJavaException(env);
+        return !clearJavaException(env);
     }
 
 private:
@@ -60,8 +62,8 @@ private:
                 = env->GetMethodID(m_javaClassRef.get(), methodName, FunctionSignature<void(Params...)>::value.data());
         }
         if (m_methodId == nullptr) {
-            checkJavaException(env);
-            throw std::runtime_error("Cannot find method in Java class");
+            clearJavaException(env);
+            fatalError("Cannot find method %s in Java class", methodName);
         }
     }
 
@@ -95,7 +97,8 @@ public:
         } else {
             static_assert(!std::is_same_v<Ret, Ret>, "Invalid JNI scalar type");
         }
-        checkJavaException(env);
+        if (clearJavaException(env))
+            return {};
         return ret;
     }
 
@@ -122,7 +125,8 @@ public:
         } else {
             static_assert(!std::is_same_v<Ret, Ret>, "Invalid JNI scalar type");
         }
-        checkJavaException(env);
+        if (clearJavaException(env))
+            return {};
         return ret;
     }
 
@@ -143,8 +147,8 @@ private:
                 = env->GetMethodID(m_javaClassRef.get(), methodName, FunctionSignature<Ret(Params...)>::value.data());
         }
         if (m_methodId == nullptr) {
-            checkJavaException(env);
-            throw std::runtime_error("Cannot find method in Java class");
+            clearJavaException(env);
+            fatalError("Cannot find method %s in Java class", methodName);
         }
     }
 
@@ -160,8 +164,7 @@ public:
     {
         auto* env = getCurrentThreadJNIEnv();
         jobject ret = env->CallObjectMethod(obj, m_methodId, params...);
-        checkJavaException(env);
-        if (ret == nullptr)
+        if (clearJavaException(env) || (ret == nullptr))
             return {};
 
         return createTypedProtectedRef(env, std::move(reinterpret_cast<Ret>(ret)));
@@ -171,8 +174,7 @@ public:
     {
         auto* env = getCurrentThreadJNIEnv();
         jobject ret = env->CallStaticObjectMethod(m_javaClassRef.get(), m_methodId, params...);
-        checkJavaException(env);
-        if (ret == nullptr)
+        if (clearJavaException(env) || (ret == nullptr))
             return {};
 
         return createTypedProtectedRef(env, std::move(reinterpret_cast<Ret>(ret)));
@@ -195,8 +197,8 @@ private:
                 = env->GetMethodID(m_javaClassRef.get(), methodName, FunctionSignature<Ret(Params...)>::value.data());
         }
         if (m_methodId == nullptr) {
-            checkJavaException(env);
-            throw std::runtime_error("Cannot find method in Java class");
+            clearJavaException(env);
+            fatalError("Cannot find method %s in Java class", methodName);
         }
     }
 

--- a/wpeview/src/main/cpp/Common/JNI/JNIObjectArray.h
+++ b/wpeview/src/main/cpp/Common/JNI/JNIObjectArray.h
@@ -35,13 +35,12 @@ public:
     ProtectedType<T> operator[](size_t index) const
     {
         if (index >= m_size)
-            throw std::out_of_range("Invalid index");
+            fatalError("Invalid index in object span");
 
         auto* env = getCurrentThreadJNIEnv();
         jobject ret = env->GetObjectArrayElement(
             reinterpret_cast<jobjectArray>(static_cast<jarray>(m_javaArrayRef.get())), static_cast<jsize>(index));
-        checkJavaException(env);
-        if (ret == nullptr)
+        if (clearJavaException(env) || (ret == nullptr))
             return {};
 
         return createTypedProtectedRef(env, std::move(reinterpret_cast<T>(ret)));
@@ -156,11 +155,7 @@ public:
         if ((thisRef == nullptr) || (otherRef == nullptr))
             return (thisRef == otherRef);
 
-        try {
-            return (getCurrentThreadJNIEnv()->IsSameObject(thisRef, otherRef) == JNI_TRUE);
-        } catch (...) {
-            return false;
-        }
+        return (getCurrentThreadJNIEnv()->IsSameObject(thisRef, otherRef) == JNI_TRUE);
     }
 
     operator ArrayType<T>() const noexcept
@@ -175,7 +170,8 @@ public:
 
         auto* env = getCurrentThreadJNIEnv();
         const jsize size = env->GetArrayLength(m_javaArrayRef.get());
-        checkJavaException(env);
+        if (clearJavaException(env))
+            return 0;
         return (size > 0) ? static_cast<size_t>(size) : 0;
     }
 
@@ -186,8 +182,7 @@ public:
 
         auto* env = getCurrentThreadJNIEnv();
         const jsize size = env->GetArrayLength(m_javaArrayRef.get());
-        checkJavaException(env);
-        if (size <= 0)
+        if (clearJavaException(env) || (size <= 0))
             return {0, {}};
 
         return {size, m_javaArrayRef};
@@ -196,12 +191,12 @@ public:
     void setValue(size_t index, const T& value)
     {
         if (m_javaArrayRef == nullptr)
-            throw std::out_of_range("Invalid index");
+            fatalError("Cannot set value on a null Java array");
 
         auto* env = getCurrentThreadJNIEnv();
         env->SetObjectArrayElement(reinterpret_cast<jobjectArray>(static_cast<jarray>(m_javaArrayRef.get())),
             static_cast<jsize>(index), value);
-        checkJavaException(env);
+        clearJavaException(env);
     }
 
 private:

--- a/wpeview/src/main/cpp/Common/JNI/JNIScalarArray.h
+++ b/wpeview/src/main/cpp/Common/JNI/JNIScalarArray.h
@@ -45,7 +45,7 @@ public:
     const T& operator[](size_t index) const
     {
         if (index >= m_size)
-            throw std::out_of_range("Invalid index");
+            fatalError("Invalid index in scalar span");
         return m_data.get()[index];
     }
 
@@ -60,7 +60,7 @@ public:
     template <typename U = T> std::enable_if_t<!isConst, U&> operator[](size_t index)
     {
         if (index >= m_size)
-            throw std::out_of_range("Invalid index");
+            fatalError("Invalid index in scalar span");
         return m_data.get()[index];
     }
 
@@ -118,8 +118,9 @@ public:
         }
 
         if (localArray == nullptr) {
-            checkJavaException(env);
-            throw std::runtime_error("Cannot create a Java array");
+            clearJavaException(env);
+            Logging::logError("Cannot create a Java array");
+            return;
         }
 
         m_javaArrayRef = createTypedProtectedRef(env, std::move(localArray), useGlobalRef);
@@ -151,11 +152,7 @@ public:
         if ((thisRef == nullptr) || (otherRef == nullptr))
             return (thisRef == otherRef);
 
-        try {
-            return (getCurrentThreadJNIEnv()->IsSameObject(thisRef, otherRef) == JNI_TRUE);
-        } catch (...) {
-            return false;
-        }
+        return (getCurrentThreadJNIEnv()->IsSameObject(thisRef, otherRef) == JNI_TRUE);
     }
 
     operator ArrayType<T>() const noexcept
@@ -170,7 +167,8 @@ public:
 
         auto* env = getCurrentThreadJNIEnv();
         const jsize size = env->GetArrayLength(m_javaArrayRef.get());
-        checkJavaException(env);
+        if (clearJavaException(env))
+            return 0;
         return (size > 0) ? static_cast<size_t>(size) : 0;
     }
 
@@ -194,8 +192,7 @@ private:
 
         auto* env = getCurrentThreadJNIEnv();
         const jsize size = env->GetArrayLength(javaArrayRef);
-        checkJavaException(env);
-        if (size <= 0)
+        if (clearJavaException(env) || (size <= 0))
             return {0, {}};
 
         T* arrayElements = nullptr;
@@ -220,34 +217,33 @@ private:
         }
 
         if (arrayElements == nullptr) {
-            checkJavaException(env);
-            throw std::runtime_error("Cannot get Java scalar array content");
+            clearJavaException(env);
+            Logging::logError("Cannot get Java scalar array content");
+            return {0, {}};
         }
 
         return {size, {arrayElements, [javaArrayRef](T* ptr) {
-                           try {
-                               auto* releaseEnv = getCurrentThreadJNIEnv();
-                               if constexpr (std::is_same_v<T, jboolean>) {
-                                   releaseEnv->ReleaseBooleanArrayElements(javaArrayRef, ptr, mode);
-                               } else if constexpr (std::is_same_v<T, jbyte>) {
-                                   releaseEnv->ReleaseByteArrayElements(javaArrayRef, ptr, mode);
-                               } else if constexpr (std::is_same_v<T, jchar>) {
-                                   releaseEnv->ReleaseCharArrayElements(javaArrayRef, ptr, mode);
-                               } else if constexpr (std::is_same_v<T, jshort>) {
-                                   releaseEnv->ReleaseShortArrayElements(javaArrayRef, ptr, mode);
-                               } else if constexpr (std::is_same_v<T, jint>) {
-                                   releaseEnv->ReleaseIntArrayElements(javaArrayRef, ptr, mode);
-                               } else if constexpr (std::is_same_v<T, jlong>) {
-                                   releaseEnv->ReleaseLongArrayElements(javaArrayRef, ptr, mode);
-                               } else if constexpr (std::is_same_v<T, jfloat>) {
-                                   releaseEnv->ReleaseFloatArrayElements(javaArrayRef, ptr, mode);
-                               } else if constexpr (std::is_same_v<T, jdouble>) {
-                                   releaseEnv->ReleaseDoubleArrayElements(javaArrayRef, ptr, mode);
-                               } else {
-                                   static_assert(!std::is_same_v<T, T>, "Invalid JNI scalar type");
-                               }
-                               // TODO NOLINTNEXTLINE(bugprone-empty-catch)
-                           } catch (...) {
+                           auto* releaseEnv = tryGetCurrentThreadJNIEnv();
+                           if (releaseEnv == nullptr)
+                               return;
+                           if constexpr (std::is_same_v<T, jboolean>) {
+                               releaseEnv->ReleaseBooleanArrayElements(javaArrayRef, ptr, mode);
+                           } else if constexpr (std::is_same_v<T, jbyte>) {
+                               releaseEnv->ReleaseByteArrayElements(javaArrayRef, ptr, mode);
+                           } else if constexpr (std::is_same_v<T, jchar>) {
+                               releaseEnv->ReleaseCharArrayElements(javaArrayRef, ptr, mode);
+                           } else if constexpr (std::is_same_v<T, jshort>) {
+                               releaseEnv->ReleaseShortArrayElements(javaArrayRef, ptr, mode);
+                           } else if constexpr (std::is_same_v<T, jint>) {
+                               releaseEnv->ReleaseIntArrayElements(javaArrayRef, ptr, mode);
+                           } else if constexpr (std::is_same_v<T, jlong>) {
+                               releaseEnv->ReleaseLongArrayElements(javaArrayRef, ptr, mode);
+                           } else if constexpr (std::is_same_v<T, jfloat>) {
+                               releaseEnv->ReleaseFloatArrayElements(javaArrayRef, ptr, mode);
+                           } else if constexpr (std::is_same_v<T, jdouble>) {
+                               releaseEnv->ReleaseDoubleArrayElements(javaArrayRef, ptr, mode);
+                           } else {
+                               static_assert(!std::is_same_v<T, T>, "Invalid JNI scalar type");
                            }
                        }}};
     }

--- a/wpeview/src/main/cpp/Common/JNI/JNIString.cpp
+++ b/wpeview/src/main/cpp/Common/JNI/JNIString.cpp
@@ -29,8 +29,9 @@ JNI::String::String(const char* str, bool useGlobalRef)
     auto* env = getCurrentThreadJNIEnv();
     jstring localString = env->NewStringUTF(str);
     if (localString == nullptr) {
-        checkJavaException(env);
-        throw std::runtime_error("Cannot create a Java string");
+        clearJavaException(env);
+        Logging::logError("Cannot create a Java string");
+        return;
     }
 
     m_javaStringRef = createTypedProtectedRef(env, std::move(localString), useGlobalRef);
@@ -56,11 +57,7 @@ bool JNI::String::operator==(const String& other) const noexcept
     if ((thisRef == nullptr) || (otherRef == nullptr))
         return (thisRef == otherRef);
 
-    try {
-        return (getCurrentThreadJNIEnv()->IsSameObject(thisRef, otherRef) == JNI_TRUE);
-    } catch (...) {
-        return false;
-    }
+    return (getCurrentThreadJNIEnv()->IsSameObject(thisRef, otherRef) == JNI_TRUE);
 }
 
 size_t JNI::String::getLength() const
@@ -70,7 +67,8 @@ size_t JNI::String::getLength() const
 
     auto* env = getCurrentThreadJNIEnv();
     const jsize length = env->GetStringUTFLength(m_javaStringRef.get());
-    checkJavaException(env);
+    if (clearJavaException(env))
+        return 0;
     return (length > 0) ? static_cast<size_t>(length) : 0;
 }
 
@@ -83,15 +81,13 @@ std::shared_ptr<const char> JNI::String::getContent() const
     auto* env = getCurrentThreadJNIEnv();
     const char* str = env->GetStringUTFChars(javaStringRef, nullptr);
     if (str == nullptr) {
-        checkJavaException(env);
-        throw std::runtime_error("Cannot get Java string content");
+        clearJavaException(env);
+        Logging::logError("Cannot get Java string content");
+        return {};
     }
 
     return {str, [javaStringRef](const char* ptr) {
-                try {
-                    getCurrentThreadJNIEnv()->ReleaseStringUTFChars(javaStringRef, ptr);
-                    // TODO NOLINTNEXTLINE(bugprone-empty-catch)
-                } catch (...) {
-                }
+                if (auto* env = tryGetCurrentThreadJNIEnv())
+                    env->ReleaseStringUTFChars(javaStringRef, ptr);
             }};
 }

--- a/wpeview/src/main/cpp/Runtime/EntryPoint.cpp
+++ b/wpeview/src/main/cpp/Runtime/EntryPoint.cpp
@@ -24,16 +24,8 @@
 
 extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* javaVM, void* /*reserved*/)
 {
-    try {
-        Init::initialize(javaVM);
-
-        WPERuntime::configureJNIMappings();
-
-        WebKit::configureJNIMappings();
-
-        return JNI::VERSION;
-    } catch (const std::exception& e) {
-        Logging::logError("Runtime: JNI_OnLoad: %s", e.what());
-        return JNI_ERR;
-    }
+    Init::initialize(javaVM);
+    WPERuntime::configureJNIMappings();
+    WebKit::configureJNIMappings();
+    return JNI::VERSION;
 }

--- a/wpeview/src/main/cpp/Runtime/WPERuntime.cpp
+++ b/wpeview/src/main/cpp/Runtime/WPERuntime.cpp
@@ -41,22 +41,13 @@ public:
 
     bool launchProcess(jlong pid, jint type, jint fileDesc) const noexcept
     {
-        try {
-            m_launchProcessMethod.invoke(m_runtimeJavaInstance.get(), pid, type, fileDesc);
-            return true;
-        } catch (const std::exception& ex) {
-            Logging::logError("Cannot launch process: %s", ex.what());
-            return false;
-        }
+        return m_launchProcessMethod.invoke(m_runtimeJavaInstance.get(), pid, type, fileDesc);
     }
 
     void terminateProcess(jlong pid) const noexcept
     {
-        try {
-            m_terminateProcessMethod.invoke(m_runtimeJavaInstance.get(), pid);
-        } catch (const std::exception& ex) {
-            Logging::logError("Cannot terminate process: %s", ex.what());
-        }
+        if (!m_terminateProcessMethod.invoke(m_runtimeJavaInstance.get(), pid))
+            Logging::logError("Cannot terminate process");
     }
 
 private:

--- a/wpeview/src/main/cpp/Service/EntryPoint.cpp
+++ b/wpeview/src/main/cpp/Service/EntryPoint.cpp
@@ -100,17 +100,12 @@ void initializeNativeMain(JNIEnv* /*env*/, jclass /*klass*/, jlong pid, jint typ
 
 extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* javaVM, void* /*reserved*/)
 {
-    try {
-        Init::initialize(javaVM);
+    Init::initialize(javaVM);
 
-        JNI::Class("org/wpewebkit/wpe/services/WPEService")
-            .registerNativeMethods(
-                JNI::StaticNativeMethod<void(jstringArray)>("setupNativeEnvironment", setupNativeEnvironment),
-                JNI::StaticNativeMethod<void(jlong, jint, jint)>("initializeNativeMain", initializeNativeMain));
+    JNI::Class("org/wpewebkit/wpe/services/WPEService")
+        .registerNativeMethods(
+            JNI::StaticNativeMethod<void(jstringArray)>("setupNativeEnvironment", setupNativeEnvironment),
+            JNI::StaticNativeMethod<void(jlong, jint, jint)>("initializeNativeMain", initializeNativeMain));
 
-        return JNI::VERSION;
-    } catch (const std::exception& e) {
-        Logging::logError("Service: JNI_OnLoad: %s", e.what());
-        return JNI_ERR;
-    }
+    return JNI::VERSION;
 }

--- a/wpeview/src/main/cpp/capi/WPEInputMethodContext.cpp
+++ b/wpeview/src/main/cpp/capi/WPEInputMethodContext.cpp
@@ -39,20 +39,14 @@ public:
 
     void onFocusIn(JNIWPEInputMethodContextFocusListener listener) const
     {
-        try {
-            m_onFocusIn.invoke(listener);
-        } catch (const std::exception& ex) {
-            Logging::logError("cannot call WPEInputMethodContext focus-in callback (%s)", ex.what());
-        }
+        if (!m_onFocusIn.invoke(listener))
+            Logging::logError("cannot call WPEInputMethodContext focus-in callback");
     }
 
     void onFocusOut(JNIWPEInputMethodContextFocusListener listener) const
     {
-        try {
-            m_onFocusOut.invoke(listener);
-        } catch (const std::exception& ex) {
-            Logging::logError("cannot call WPEInputMethodContext focus-out callback (%s)", ex.what());
-        }
+        if (!m_onFocusOut.invoke(listener))
+            Logging::logError("cannot call WPEInputMethodContext focus-out callback");
     }
 
 private:

--- a/wpeview/src/main/cpp/capi/WebKitCookieManager.cpp
+++ b/wpeview/src/main/cpp/capi/WebKitCookieManager.cpp
@@ -39,11 +39,8 @@ public:
 
     void onResult(JNIWebKitCookieManagerAcceptPolicyCallbackHolder callbackHolder, jint policy) const
     {
-        try {
-            m_commitResult.invoke(callbackHolder, policy);
-        } catch (const std::exception& ex) {
-            Logging::logError("cannot call WebKitCookieManager accept-policy callback (%s)", ex.what());
-        }
+        if (!m_commitResult.invoke(callbackHolder, policy))
+            Logging::logError("cannot call WebKitCookieManager accept-policy callback");
     }
 
 private:

--- a/wpeview/src/main/cpp/capi/WebKitWebContext.cpp
+++ b/wpeview/src/main/cpp/capi/WebKitWebContext.cpp
@@ -17,7 +17,6 @@
  */
 
 #include "JNI/JNI.h"
-#include "Logging.h"
 
 #include <wpe/webkit.h>
 
@@ -143,13 +142,8 @@ jlong JNIWebKitWebContextCache::nativeGetWebKitWebContextPtr(JNIEnv*, jobject, j
 
 WebKitWebView* JNIWebKitWebContextCache::invokeCreateWebKitWebViewForAutomation(JNIWebKitWebContext javaContext) const
 {
-    try {
-        const auto webViewPtr = m_invokeCreateWebKitWebViewForAutomation.invoke(javaContext);
-        return webViewPtr ? reinterpret_cast<WebKitWebView*>(webViewPtr) : nullptr;
-    } catch (const std::exception& ex) {
-        Logging::logError("cannot create automation web view (%s)", ex.what());
-        return nullptr;
-    }
+    const auto webViewPtr = m_invokeCreateWebKitWebViewForAutomation.invoke(javaContext);
+    return webViewPtr ? reinterpret_cast<WebKitWebView*>(webViewPtr) : nullptr;
 }
 
 void configureWebKitWebContextJNIMappings()

--- a/wpeview/src/main/cpp/capi/WebKitWebView.cpp
+++ b/wpeview/src/main/cpp/capi/WebKitWebView.cpp
@@ -62,11 +62,8 @@ public:
         if (!holder)
             return;
 
-        try {
-            m_commitResult.invoke(holder, result);
-        } catch (const std::exception& ex) {
-            Logging::logError("cannot call WebKitWebView eval callback (%s)", ex.what());
-        }
+        if (!m_commitResult.invoke(holder, result))
+            Logging::logError("cannot call WebKitWebView eval callback");
     }
 
 private:
@@ -155,11 +152,8 @@ const JNIWebKitWebViewCache& getJNIWebKitWebViewCache()
 
 void JNIWebKitWebViewCache::onClose(WebKitWebView*, WebKitWebViewBridge* bridge)
 {
-    try {
-        getJNIWebKitWebViewCache().m_onClose.invoke(bridge->m_javaRef.get());
-    } catch (const std::exception& ex) {
-        Logging::logError("cannot deliver WebKitWebView onClose callback (%s)", ex.what());
-    }
+    if (!getJNIWebKitWebViewCache().m_onClose.invoke(bridge->m_javaRef.get()))
+        Logging::logError("cannot deliver WebKitWebView onClose callback");
 }
 
 void JNIWebKitWebViewCache::onLoadChanged(
@@ -168,52 +162,37 @@ void JNIWebKitWebViewCache::onLoadChanged(
     // WEBKIT_LOAD_REDIRECTED and WEBKIT_LOAD_COMMITTED are intentionally not surfaced.
     if (loadEvent == WEBKIT_LOAD_STARTED) {
         auto jUri = JNI::String(webkit_web_view_get_uri(webView));
-        try {
-            getJNIWebKitWebViewCache().m_onLoadStarted.invoke(bridge->m_javaRef.get(), static_cast<jstring>(jUri));
-        } catch (const std::exception& ex) {
-            Logging::logError("cannot deliver WebKitWebView onLoadStarted callback (%s)", ex.what());
-        }
+        if (!getJNIWebKitWebViewCache().m_onLoadStarted.invoke(bridge->m_javaRef.get(), static_cast<jstring>(jUri)))
+            Logging::logError("cannot deliver WebKitWebView onLoadStarted callback");
     } else if (loadEvent == WEBKIT_LOAD_FINISHED) {
         auto jUri = JNI::String(webkit_web_view_get_uri(webView));
-        try {
-            getJNIWebKitWebViewCache().m_onLoadFinished.invoke(bridge->m_javaRef.get(), static_cast<jstring>(jUri));
-        } catch (const std::exception& ex) {
-            Logging::logError("cannot deliver WebKitWebView onLoadFinished callback (%s)", ex.what());
-        }
+        if (!getJNIWebKitWebViewCache().m_onLoadFinished.invoke(bridge->m_javaRef.get(), static_cast<jstring>(jUri)))
+            Logging::logError("cannot deliver WebKitWebView onLoadFinished callback");
     }
 }
 
 void JNIWebKitWebViewCache::onUriChanged(GObject* obj, GParamSpec*, WebKitWebViewBridge* bridge)
 {
     auto jUri = JNI::String(webkit_web_view_get_uri(WEBKIT_WEB_VIEW(obj)));
-    try {
-        getJNIWebKitWebViewCache().m_onUriChanged.invoke(bridge->m_javaRef.get(), static_cast<jstring>(jUri));
-    } catch (const std::exception& ex) {
-        Logging::logError("cannot deliver WebKitWebView onUriChanged callback (%s)", ex.what());
-    }
+    if (!getJNIWebKitWebViewCache().m_onUriChanged.invoke(bridge->m_javaRef.get(), static_cast<jstring>(jUri)))
+        Logging::logError("cannot deliver WebKitWebView onUriChanged callback");
 }
 
 void JNIWebKitWebViewCache::onEstimatedLoadProgress(GObject* obj, GParamSpec*, WebKitWebViewBridge* bridge)
 {
     double progress = webkit_web_view_get_estimated_load_progress(WEBKIT_WEB_VIEW(obj));
-    try {
-        getJNIWebKitWebViewCache().m_onEstimatedLoadProgress.invoke(bridge->m_javaRef.get(), progress);
-    } catch (const std::exception& ex) {
-        Logging::logError("cannot deliver WebKitWebView onEstimatedLoadProgress callback (%s)", ex.what());
-    }
+    if (!getJNIWebKitWebViewCache().m_onEstimatedLoadProgress.invoke(bridge->m_javaRef.get(), progress))
+        Logging::logError("cannot deliver WebKitWebView onEstimatedLoadProgress callback");
 }
 
 void JNIWebKitWebViewCache::onTitleChanged(GObject* obj, GParamSpec*, WebKitWebViewBridge* bridge)
 {
     auto* webView = WEBKIT_WEB_VIEW(obj);
     auto jTitle = JNI::String(webkit_web_view_get_title(webView));
-    try {
-        getJNIWebKitWebViewCache().m_onTitleChanged.invoke(bridge->m_javaRef.get(), static_cast<jstring>(jTitle),
+    if (!getJNIWebKitWebViewCache().m_onTitleChanged.invoke(bridge->m_javaRef.get(), static_cast<jstring>(jTitle),
             static_cast<jboolean>(webkit_web_view_can_go_back(webView)),
-            static_cast<jboolean>(webkit_web_view_can_go_forward(webView)));
-    } catch (const std::exception& ex) {
-        Logging::logError("cannot deliver WebKitWebView onTitleChanged callback (%s)", ex.what());
-    }
+            static_cast<jboolean>(webkit_web_view_can_go_forward(webView))))
+        Logging::logError("cannot deliver WebKitWebView onTitleChanged callback");
 }
 
 gboolean JNIWebKitWebViewCache::onDecidePolicy(
@@ -233,12 +212,9 @@ gboolean JNIWebKitWebViewCache::onDecidePolicy(
     auto jUri = JNI::String(webkit_uri_request_get_uri(uriRequest));
     auto jMethod = JNI::String(method ? method : "GET");
     auto jMimeType = JNI::String(webkit_uri_response_get_mime_type(uriResponse));
-    try {
-        getJNIWebKitWebViewCache().m_onReceivedHttpError.invoke(bridge->m_javaRef.get(), static_cast<jstring>(jUri),
-            static_cast<jstring>(jMethod), static_cast<jstring>(jMimeType), static_cast<jint>(statusCode));
-    } catch (const std::exception& ex) {
-        Logging::logError("cannot deliver WebKitWebView onReceivedHttpError callback (%s)", ex.what());
-    }
+    if (!getJNIWebKitWebViewCache().m_onReceivedHttpError.invoke(bridge->m_javaRef.get(), static_cast<jstring>(jUri),
+            static_cast<jstring>(jMethod), static_cast<jstring>(jMimeType), static_cast<jint>(statusCode)))
+        Logging::logError("cannot deliver WebKitWebView onReceivedHttpError callback");
 
     return FALSE;
 }
@@ -257,11 +233,9 @@ gboolean JNIWebKitWebViewCache::onScriptDialog(
     JNI::String jDefaultText = type == WEBKIT_SCRIPT_DIALOG_PROMPT
         ? JNI::String(webkit_script_dialog_prompt_get_default_text(dialog))
         : JNI::String("");
-    try {
-        getJNIWebKitWebViewCache().m_onScriptDialog.invoke(bridge->m_javaRef.get(), dialogPtr, static_cast<jint>(type),
-            static_cast<jstring>(jUrl), static_cast<jstring>(jMessage), static_cast<jstring>(jDefaultText));
-    } catch (const std::exception& ex) {
-        Logging::logError("cannot deliver WebKitWebView onScriptDialog callback (%s)", ex.what());
+    if (!getJNIWebKitWebViewCache().m_onScriptDialog.invoke(bridge->m_javaRef.get(), dialogPtr, static_cast<jint>(type),
+            static_cast<jstring>(jUrl), static_cast<jstring>(jMessage), static_cast<jstring>(jDefaultText))) {
+        Logging::logError("cannot deliver WebKitWebView onScriptDialog callback");
         webkit_script_dialog_unref(dialog);
         return FALSE;
     }

--- a/wpeview/src/main/cpp/capi/WebKitWebsiteDataManager.cpp
+++ b/wpeview/src/main/cpp/capi/WebKitWebsiteDataManager.cpp
@@ -39,11 +39,8 @@ public:
 
     void onResult(JNIWebKitWebsiteDataManagerCallbackHolder callbackHolder, jboolean result) const
     {
-        try {
-            m_commitResult.invoke(callbackHolder, result);
-        } catch (const std::exception& ex) {
-            Logging::logError("cannot call WebKitWebsiteDataManager callback result (%s)", ex.what());
-        }
+        if (!m_commitResult.invoke(callbackHolder, result))
+            Logging::logError("cannot call WebKitWebsiteDataManager callback result");
     }
 
 private:


### PR DESCRIPTION
Stop using C++ exceptions for JNI error handling and compile with -fno-exceptions. Unrecoverable usage errors (missing class, method or field, native method registration failures, JNIEnv setup) now log and abort through JNI::fatalError, matching the previous outcome where the exception aborted library loading. Runtime failures use the new JNI::clearJavaException helper: it logs and clears any pending Java exception, void method invocations return a success boolean, and value returning helpers fall back to a default value. This removes all the try/catch blocks at the JNI boundaries; JNI::Class lookup by name keeps returning a null class so Init.cpp can probe for optional classes.