### PR TITLE
Bump to wpewebkit 2.55.0.1

### DIFF
--- a/tools/scripts/bootstrap.py
+++ b/tools/scripts/bootstrap.py
@@ -81,7 +81,7 @@ from urllib.request import urlretrieve
 
 class Bootstrap:
     default_arch = "arm64"
-    default_version = "2.53.3.8"
+    default_version = "2.55.0.1"
 
     _cerbero_origin = "https://github.com/Igalia/wpe-android-cerbero.git"
     _cerbero_branch = "main"


### PR DESCRIPTION
 Bump of the prebuilt wpewebkit to 2.55.0.1 (WebKit 2507145). Upstream trunk moved to SET_PROJECT_VERSION(2 55 0), so this leaves the 2.53.3.x line.
